### PR TITLE
Add Multi-transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ The MCP CAPI Server provides a bridge between AI assistants (like Claude, GPT, e
 - **Real-time Monitoring**: Watch cluster status changes and events
 - **Resource Discovery**: Browse CAPI resources through MCP resources
 - **Guided Workflows**: Interactive prompts for complex operations
+- **Multi-Transport Support**: Connect via stdio, Server-Sent Events (SSE), or Streamable HTTP
+- **Enhanced CLI**: Version management, self-update capability, and comprehensive help system
+- **Backwards Compatible**: Maintains compatibility with existing configurations and scripts
 
 ## Architecture
 
@@ -26,7 +29,7 @@ The MCP CAPI Server is built using:
 
 ### Prerequisites
 
-- Go 1.22 or later
+- Go 1.24.4 or later
 - Access to a CAPI management cluster
 - Kubeconfig configured for the management cluster
 
@@ -44,16 +47,156 @@ make build
 make run
 ```
 
-### Basic Usage
+### Self-Update
 
-The server can be run in different transport modes:
+The server includes a built-in self-update mechanism:
 
 ```bash
-# Stdio transport (default)
-./bin/mcp-capi
+mcp-capi self-update
+```
 
-# With environment variables
-MCP_TRANSPORT=stdio ./bin/mcp-capi
+## Usage
+
+### CLI Commands
+
+The MCP server provides several commands:
+
+```bash
+$ mcp-capi --help
+mcp-capi is a Model Context Protocol (MCP) server that provides
+tools for interacting with Cluster API (CAPI) clusters. It offers various capabilities
+including cluster management, machine operations, scaling, and infrastructure 
+provider management.
+
+When run without subcommands, it starts the MCP server (equivalent to 'mcp-capi serve').
+
+Usage:
+  mcp-capi [command]
+
+Available Commands:
+  completion  Generate the autocompletion script for the specified shell
+  help        Help about any command
+  self-update Update mcp-capi to the latest version
+  serve       Start the MCP CAPI server
+  version     Print the version number of mcp-capi
+
+Flags:
+  -h, --help      help for mcp-capi
+  -v, --version   version for mcp-capi
+
+Use "mcp-capi [command] --help" for more information about a command.
+```
+
+### Basic Usage (Backwards Compatible)
+
+Start the MCP server with default settings using stdio transport:
+
+```bash
+# Both commands are equivalent and start the server
+mcp-capi
+mcp-capi serve
+```
+
+### Multi-Transport Support
+
+The server supports three transport types for different deployment scenarios:
+
+#### Standard I/O (Default)
+Best for MCP client integrations and development:
+
+```bash
+mcp-capi serve --transport stdio
+```
+
+#### Server-Sent Events (SSE)
+Ideal for web applications and browser-based clients:
+
+```bash
+mcp-capi serve --transport sse --http-addr :8080
+```
+
+#### Streamable HTTP
+Perfect for HTTP-based integrations and REST-like interactions:
+
+```bash
+mcp-capi serve --transport streamable-http --http-addr :8080
+```
+
+### Advanced Configuration Examples
+
+```bash
+# Run with SSE transport on custom port with custom endpoints
+mcp-capi serve \
+  --transport sse \
+  --http-addr :9090 \
+  --sse-endpoint /events \
+  --message-endpoint /messages
+
+# Run with streamable HTTP transport
+mcp-capi serve \
+  --transport streamable-http \
+  --http-addr :8080 \
+  --http-endpoint /api/mcp
+```
+
+### Version Management
+
+```bash
+# Check current version
+mcp-capi version
+mcp-capi --version
+
+# Update to latest version
+mcp-capi self-update
+```
+
+## Integration with AI Assistants
+
+This MCP server can be integrated with various AI assistants that support the Model Context Protocol:
+
+- **Cursor**: The server can be integrated with Cursor for AI-powered development
+- **VSCode Insiders**: Compatible with VSCode Insiders for enhanced coding assistance
+- **Claude Desktop**: Add the server to your Claude Desktop configuration
+- **Custom MCP Clients**: Use any MCP-compatible client to connect
+
+### Example MCP Client Configuration
+
+#### Standard I/O Transport (Recommended)
+```json
+{
+  "servers": {
+    "capi": {
+      "command": "/path/to/mcp-capi",
+      "env": {
+        "KUBECONFIG": "/path/to/kubeconfig"
+      }
+    }
+  }
+}
+```
+
+#### SSE Transport
+```json
+{
+  "servers": {
+    "capi": {
+      "url": "http://localhost:8080/sse",
+      "transport": "sse"
+    }
+  }
+}
+```
+
+#### Streamable HTTP Transport
+```json
+{
+  "servers": {
+    "capi": {
+      "url": "http://localhost:8080/mcp",
+      "transport": "http"
+    }
+  }
+}
 ```
 
 ## Available Tools
@@ -125,21 +268,75 @@ The server exposes CAPI data through MCP resources:
 - `capi://machines` - List of all machines
 - `capi://providers` - Available infrastructure providers
 
+## Configuration
+
+The server can be configured through environment variables:
+
+- `KUBECONFIG` - Path to kubeconfig file
+- `LOG_LEVEL` - Logging level (debug, info, warn, error)
+
+## Deployment
+
+### Docker
+
+You can run the server in a Docker container:
+
+```dockerfile
+FROM golang:1.24.4-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN go build -o mcp-capi
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=builder /app/mcp-capi .
+EXPOSE 8080
+CMD ["./mcp-capi", "serve", "--transport", "sse", "--http-addr", ":8080"]
+```
+
+### Systemd Service
+
+Create a systemd service for automatic startup:
+
+```ini
+[Unit]
+Description=MCP CAPI Server
+After=network.target
+
+[Service]
+Type=simple
+User=capi
+ExecStart=/usr/local/bin/mcp-capi serve
+Environment=KUBECONFIG=/etc/kubernetes/admin.conf
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
 ## Development
 
 ### Project Structure
 
 ```
 mcp-capi/
-├── cmd/mcp-capi/       # Main application entry point
-├── pkg/                # Public packages
-│   ├── capi/          # CAPI client and utilities
-│   ├── tools/         # MCP tool implementations
-│   ├── resources/     # MCP resource handlers
-│   └── prompts/       # MCP prompt definitions
-├── internal/           # Private packages
-├── docs/              # Documentation
-└── examples/          # Usage examples
+├── cmd/                    # Command implementations
+│   ├── root.go            # Root Cobra command
+│   ├── serve.go           # Server command with multi-transport support
+│   ├── version.go         # Version command
+│   ├── selfupdate.go      # Self-update command
+│   ├── doc.go             # Package documentation
+│   └── *.go               # Tool handlers and server logic
+├── pkg/                   # Public packages
+│   ├── capi/             # CAPI client and utilities
+│   ├── tools/            # MCP tool implementations
+│   ├── resources/        # MCP resource handlers
+│   └── prompts/          # MCP prompt definitions
+├── internal/             # Private packages
+├── docs/                 # Documentation
+└── examples/             # Usage examples
 ```
 
 ### Building
@@ -161,14 +358,6 @@ make test-coverage
 ### Contributing
 
 Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to contribute to this project.
-
-## Configuration
-
-The server can be configured through environment variables:
-
-- `KUBECONFIG` - Path to kubeconfig file
-- `MCP_TRANSPORT` - Transport type (stdio, sse, http)
-- `LOG_LEVEL` - Logging level (debug, info, warn, error)
 
 ## License
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -4,9 +4,13 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"os/signal"
+	"strconv"
+	"strings"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -48,6 +52,10 @@ Supports multiple transport types:
   - sse: Server-Sent Events over HTTP
   - streamable-http: Streamable HTTP transport`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Validate input parameters before starting server
+			if err := validateServeFlags(transport, httpAddr, sseEndpoint, messageEndpoint, httpEndpoint); err != nil {
+				return fmt.Errorf("invalid configuration: %w", err)
+			}
 			return runServe(transport, httpAddr, sseEndpoint, messageEndpoint, httpEndpoint)
 		},
 	}
@@ -60,6 +68,89 @@ Supports multiple transport types:
 	cmd.Flags().StringVar(&httpEndpoint, "http-endpoint", "/mcp", "HTTP endpoint path (for streamable-http transport)")
 
 	return cmd
+}
+
+// validateServeFlags validates the input parameters for the serve command
+func validateServeFlags(transport, httpAddr, sseEndpoint, messageEndpoint, httpEndpoint string) error {
+	// Validate transport type
+	validTransports := []string{"stdio", "sse", "streamable-http"}
+	isValidTransport := false
+	for _, valid := range validTransports {
+		if transport == valid {
+			isValidTransport = true
+			break
+		}
+	}
+	if !isValidTransport {
+		return fmt.Errorf("unsupported transport type: %s (supported: %s)", transport, strings.Join(validTransports, ", "))
+	}
+
+	// Validate HTTP address for non-stdio transports
+	if transport != "stdio" {
+		if err := validateHTTPAddr(httpAddr); err != nil {
+			return fmt.Errorf("invalid http-addr: %w", err)
+		}
+	}
+
+	// Validate endpoint paths
+	endpoints := map[string]string{
+		"sse-endpoint":     sseEndpoint,
+		"message-endpoint": messageEndpoint,
+		"http-endpoint":    httpEndpoint,
+	}
+	
+	for name, endpoint := range endpoints {
+		if err := validateEndpointPath(endpoint); err != nil {
+			return fmt.Errorf("invalid %s: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
+// validateHTTPAddr validates HTTP address format
+func validateHTTPAddr(addr string) error {
+	if addr == "" {
+		return fmt.Errorf("address cannot be empty")
+	}
+
+	// Parse the address
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return fmt.Errorf("invalid address format: %w", err)
+	}
+
+	// Validate port
+	if portStr != "" {
+		port, err := strconv.Atoi(portStr)
+		if err != nil {
+			return fmt.Errorf("invalid port number: %w", err)
+		}
+		if port < 1 || port > 65535 {
+			return fmt.Errorf("port number must be between 1 and 65535, got: %d", port)
+		}
+	}
+
+	// Validate host (if specified)
+	if host != "" && net.ParseIP(host) == nil && host != "localhost" {
+		return fmt.Errorf("invalid host address: %s", host)
+	}
+
+	return nil
+}
+
+// validateEndpointPath validates HTTP endpoint paths
+func validateEndpointPath(path string) error {
+	if path == "" {
+		return fmt.Errorf("endpoint path cannot be empty")
+	}
+	if !strings.HasPrefix(path, "/") {
+		return fmt.Errorf("endpoint path must start with '/', got: %s", path)
+	}
+	if strings.Contains(path, " ") {
+		return fmt.Errorf("endpoint path cannot contain spaces, got: %s", path)
+	}
+	return nil
 }
 
 // runServe contains the main server logic with support for multiple transports
@@ -87,6 +178,7 @@ func runServe(transport, httpAddr, sseEndpoint, messageEndpoint, httpEndpoint st
 	// Initialize providers
 	if err := capiClient.InitializeProviders(); err != nil {
 		log.Printf("Warning: Failed to initialize providers: %v", err)
+		log.Printf("Server will continue but some provider-specific tools may not work")
 	}
 
 	// Create server context
@@ -120,6 +212,7 @@ func runServe(transport, httpAddr, sseEndpoint, messageEndpoint, httpEndpoint st
 	case "streamable-http":
 		return runStreamableHTTPServer(mcpServer, httpAddr, httpEndpoint, ctx)
 	default:
+		// This should never happen due to validation, but keep as safety net
 		return fmt.Errorf("unsupported transport type: %s (supported: stdio, sse, streamable-http)", transport)
 	}
 }
@@ -174,7 +267,7 @@ func runSSEServer(mcpSrv *mcpserver.MCPServer, addr, sseEndpoint, messageEndpoin
 	select {
 	case <-ctx.Done():
 		fmt.Println("Shutdown signal received, stopping SSE server...")
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		if err := sseServer.Shutdown(shutdownCtx); err != nil {
 			return fmt.Errorf("error shutting down SSE server: %w", err)
@@ -214,7 +307,7 @@ func runStreamableHTTPServer(mcpSrv *mcpserver.MCPServer, addr, endpoint string,
 	select {
 	case <-ctx.Done():
 		fmt.Println("Shutdown signal received, stopping HTTP server...")
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		if err := httpServer.Shutdown(shutdownCtx); err != nil {
 			return fmt.Errorf("error shutting down HTTP server: %w", err)


### PR DESCRIPTION
**Documentation Enhancements:**
- Update README with new cmd architecture and multi-transport support
- Document CLI commands (serve, version, self-update)
- Add comprehensive usage examples for all transport types
- Include deployment examples (Docker, systemd)
- Update prerequisites to Go 1.24.4
- Add backwards compatibility documentation

**Safety Features:**
- Add comprehensive input validation for serve command
- Validate transport types with clear error messages
- Validate HTTP addresses and port ranges (1-65535)
- Validate endpoint paths (must start with /, no spaces)
- Add proper error wrapping with context
- Improve shutdown timeout handling with explicit durations
- Add graceful error handling for provider initialization failures

**Architecture Updates:**
- Update project structure documentation
- Add integration examples for different MCP clients
- Document multi-transport deployment scenarios

Phase 3 completes the alignment bringing mcp-capi to feature parity with other MCP servers while maintaining full backwards compatibility.