### PR TITLE
ci: fix pre-commit auto-formatter and test violations

### DIFF
--- a/.cursor/rules/closing-issue-workflow.mdc
+++ b/.cursor/rules/closing-issue-workflow.mdc
@@ -1,6 +1,6 @@
 ---
-description: 
-globs: 
+description:
+globs:
 alwaysApply: true
 ---
 When closing an issue:

--- a/.cursor/rules/commit-and-push-workflow.mdc
+++ b/.cursor/rules/commit-and-push-workflow.mdc
@@ -1,6 +1,6 @@
 ---
-description: 
-globs: 
+description:
+globs:
 alwaysApply: false
 ---
 When committing and pushing changes after an issue is successfully closed and tests have passed:

--- a/.cursor/rules/creating-issue-workflow.mdc
+++ b/.cursor/rules/creating-issue-workflow.mdc
@@ -1,6 +1,6 @@
 ---
-description: 
-globs: 
+description:
+globs:
 alwaysApply: true
 ---
 When creating a new issue:

--- a/.cursor/rules/docs-guidelines.mdc
+++ b/.cursor/rules/docs-guidelines.mdc
@@ -1,10 +1,10 @@
 ---
-description: 
-globs: 
+description:
+globs:
 alwaysApply: true
 ---
 ## Docs Guidelines
 
-When implementing new features or fixing bugs, ensure the docs are updated. 
+When implementing new features or fixing bugs, ensure the docs are updated.
 
 Update the README.md and the markdown files in `./docs` and the packages contain `doc.go` files.

--- a/.cursor/rules/file-length-guidelines.mdc
+++ b/.cursor/rules/file-length-guidelines.mdc
@@ -1,6 +1,6 @@
 ---
-description: 
-globs: 
+description:
+globs:
 alwaysApply: true
 ---
 ## File Length Guidelines

--- a/.cursor/rules/go-guidelines.mdc
+++ b/.cursor/rules/go-guidelines.mdc
@@ -1,6 +1,6 @@
 ---
-description: 
-globs: 
+description:
+globs:
 alwaysApply: true
 ---
 ## Go Guidelines

--- a/.cursor/rules/next-issue-workflow.mdc
+++ b/.cursor/rules/next-issue-workflow.mdc
@@ -1,6 +1,6 @@
 ---
-description: 
-globs: 
+description:
+globs:
 alwaysApply: true
 ---
 When beginning work on a new task:

--- a/.cursor/rules/rules/architecture.mdc
+++ b/.cursor/rules/rules/architecture.mdc
@@ -1,6 +1,6 @@
 ---
-description: 
-globs: 
+description:
+globs:
 alwaysApply: true
 ---
 # Architecture Principles

--- a/.cursor/rules/rules/cursor_rules.mdc
+++ b/.cursor/rules/rules/cursor_rules.mdc
@@ -27,7 +27,7 @@ alwaysApply: true
   ```typescript
   // ✅ DO: Show good examples
   const goodExample = true;
-  
+
   // ❌ DON'T: Show anti-patterns
   const badExample = false;
   ```
@@ -50,4 +50,4 @@ alwaysApply: true
   - Keep descriptions concise
   - Include both DO and DON'T examples
   - Reference actual code over theoretical examples
-  - Use consistent formatting across rules 
+  - Use consistent formatting across rules

--- a/.cursor/rules/rules/dev_workflow.mdc
+++ b/.cursor/rules/rules/dev_workflow.mdc
@@ -173,9 +173,9 @@ This project uses **Task Master** for task management. While the principles of t
     - Dependencies are displayed with status indicators (✅ for completed, ⏱️ for pending)
     - This helps quickly identify which prerequisite tasks are blocking work
 - **priority**: Importance level (Example: `"high"`, `"medium"`, `"low"`)
-- **details**: In-depth implementation instructions (Example: `"Use GitHub client ID/secret, handle callback, set session token."`) 
-- **testStrategy**: Verification approach (Example: `"Deploy and call endpoint to confirm 'Hello World' response."`) 
-- **subtasks**: List of smaller, more specific tasks (Example: `[{"id": 1, "title": "Configure OAuth", ...}]`) 
+- **details**: In-depth implementation instructions (Example: `"Use GitHub client ID/secret, handle callback, set session token."`)
+- **testStrategy**: Verification approach (Example: `"Deploy and call endpoint to confirm 'Hello World' response."`)
+- **subtasks**: List of smaller, more specific tasks (Example: `[{"id": 1, "title": "Configure OAuth", ...}]`)
 - Refer to task structure details (previously linked to `tasks.mdc`).
 
 ## Configuration Management (Updated)
@@ -238,7 +238,7 @@ Taskmaster configuration is managed through two main mechanisms:
 - Use `move_task` / `task-master move --from=<id> --to=<id>` to move tasks or subtasks within the hierarchy
 - This command supports several use cases:
   - Moving a standalone task to become a subtask (e.g., `--from=5 --to=7`)
-  - Moving a subtask to become a standalone task (e.g., `--from=5.2 --to=7`) 
+  - Moving a subtask to become a standalone task (e.g., `--from=5.2 --to=7`)
   - Moving a subtask to a different parent (e.g., `--from=5.2 --to=7.3`)
   - Reordering subtasks within the same parent (e.g., `--from=5.2 --to=5.4`)
   - Moving a task to a new, non-existent ID position (e.g., `--from=5 --to=25`)

--- a/.cursor/rules/rules/mcp-debugging.mdc
+++ b/.cursor/rules/rules/mcp-debugging.mdc
@@ -1,6 +1,6 @@
 ---
-description: 
-globs: 
+description:
+globs:
 alwaysApply: true
 ---
 ## Debugging mcp-capi via mcp-debug

--- a/.cursor/rules/rules/self_improve.mdc
+++ b/.cursor/rules/rules/self_improve.mdc
@@ -38,7 +38,7 @@ alwaysApply: true
     select: { id: true, email: true },
     where: { status: 'ACTIVE' }
   });
-  
+
   // Consider adding to [prisma.mdc](mdc:.cursor/rules/prisma.mdc):
   // - Standard select fields
   // - Common where conditions

--- a/.cursor/rules/rules/taskmaster.mdc
+++ b/.cursor/rules/rules/taskmaster.mdc
@@ -7,7 +7,7 @@ alwaysApply: true
 
 This document provides a detailed reference for interacting with Taskmaster, covering both the recommended MCP tools, suitable for integrations like Cursor, and the corresponding `task-master` CLI commands, designed for direct user interaction or fallback.
 
-**Note:** For interacting with Taskmaster programmatically or via integrated tools, using the **MCP tools is strongly recommended** due to better performance, structured data, and error handling. The CLI commands serve as a user-friendly alternative and fallback. 
+**Note:** For interacting with Taskmaster programmatically or via integrated tools, using the **MCP tools is strongly recommended** due to better performance, structured data, and error handling. The CLI commands serve as a user-friendly alternative and fallback.
 
 **Important:** Several MCP tools involve AI processing... The AI-powered tools include `parse_prd`, `analyze_project_complexity`, `update_subtask`, `update_task`, `update`, `expand_all`, `expand_task`, and `add_task`.
 
@@ -35,8 +35,8 @@ This document provides a detailed reference for interacting with Taskmaster, cov
     *   `skipInstall`: `Skip installing dependencies. Default is false.` (CLI: `--skip-install`)
     *   `addAliases`: `Add shell aliases tm and taskmaster. Default is false.` (CLI: `--aliases`)
     *   `yes`: `Skip prompts and use defaults/provided arguments. Default is false.` (CLI: `-y, --yes`)
-*   **Usage:** Run this once at the beginning of a new project, typically via an integrated tool like Cursor. Operates on the current working directory of the MCP server. 
-*   **Important:** Once complete, you *MUST* parse a prd in order to generate tasks. There will be no tasks files until then. The next step after initializing should be to create a PRD using the example PRD in .taskmaster/templates/example_prd.txt. 
+*   **Usage:** Run this once at the beginning of a new project, typically via an integrated tool like Cursor. Operates on the current working directory of the MCP server.
+*   **Important:** Once complete, you *MUST* parse a prd in order to generate tasks. There will be no tasks files until then. The next step after initializing should be to create a PRD using the example PRD in .taskmaster/templates/example_prd.txt.
 
 ### 2. Parse PRD (`parse_prd`)
 
@@ -79,7 +79,7 @@ This document provides a detailed reference for interacting with Taskmaster, cov
 *   **Usage (CLI):** Run without flags to view current configuration and available models. Use set flags to update specific roles. Use `--setup` for guided configuration, including custom models. To set a custom model via flags, use `--set-<role>=<model_id>` along with either `--ollama` or `--openrouter`.
 *   **Notes:** Configuration is stored in `.taskmaster/config.json` in the project root. This command/tool modifies that file. Use `listAvailableModels` or `task-master models` to see internally supported models. OpenRouter custom models are validated against their live API. Ollama custom models are not validated live.
 *   **API note:** API keys for selected AI providers (based on their model) need to exist in the mcp.json file to be accessible in MCP context. The API keys must be present in the local .env file for the CLI to be able to read them.
-*   **Model costs:** The costs in supported models are expressed in dollars. An input/output value of 3 is $3.00. A value of 0.8 is $0.80. 
+*   **Model costs:** The costs in supported models are expressed in dollars. An input/output value of 3 is $3.00. A value of 0.8 is $0.80.
 *   **Warning:** DO NOT MANUALLY EDIT THE .taskmaster/config.json FILE. Use the included commands either in the MCP or CLI format as needed. Always prioritize MCP tools when available and use the CLI as a fallback.
 
 ---

--- a/.cursor/rules/testing-guidelines.mdc
+++ b/.cursor/rules/testing-guidelines.mdc
@@ -1,6 +1,6 @@
 ---
-description: 
-globs: 
+description:
+globs:
 alwaysApply: true
 ---
 ## Testing Guidelines

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,11 @@ jobs:
           chmod +x "$(go env GOPATH)/bin/kube-apiserver"
 
       - name: Run yamllint
-        run: yamllint .github/workflows/auto-release.yaml .github/workflows/ci.yaml .goreleaser.yaml
+        run: >-
+          yamllint
+          .github/workflows/auto-release.yaml
+          .github/workflows/ci.yaml
+          .goreleaser.yaml
 
       - name: Run lint
         run: make lint
@@ -67,7 +71,9 @@ jobs:
       - name: Run Release Dry-Run
         # Only run on PRs, not on direct pushes to main
         if: github.event_name == 'pull_request'
-        run: goreleaser release --snapshot --clean --skip=announce,publish,validate
+        run: >-
+          goreleaser release --snapshot --clean
+          --skip=announce,publish,validate
         env:
           # GoReleaser needs a GITHUB_TOKEN even for dry runs
           # to check API rate limits, etc.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,8 +47,14 @@ jobs:
             -o "$(go env GOPATH)/bin/kube-apiserver"
           chmod +x "$(go env GOPATH)/bin/kube-apiserver"
 
-      - name: Run Checks (Lint & Test)
-        run: make check
+      - name: Run yamllint
+        run: yamllint .github/workflows/auto-release.yaml .github/workflows/ci.yaml .goreleaser.yaml
+
+      - name: Run lint
+        run: make lint
+
+      - name: Run tests
+        run: make test
 
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v7
@@ -61,7 +67,7 @@ jobs:
       - name: Run Release Dry-Run
         # Only run on PRs, not on direct pushes to main
         if: github.event_name == 'pull_request'
-        run: make release-dry-run
+        run: goreleaser release --snapshot --clean --skip=announce,publish,validate
         env:
           # GoReleaser needs a GITHUB_TOKEN even for dry runs
           # to check API rate limits, etc.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,4 +138,4 @@ git push upstream v0.1.0
 
 Contributors will be recognized in our releases and documentation.
 
-Thank you for contributing! 
+Thank you for contributing!

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The MCP server provides several commands:
 $ mcp-capi --help
 mcp-capi is a Model Context Protocol (MCP) server that provides
 tools for interacting with Cluster API (CAPI) clusters. It offers various capabilities
-including cluster management, machine operations, scaling, and infrastructure 
+including cluster management, machine operations, scaling, and infrastructure
 provider management.
 
 When run without subcommands, it starts the MCP server (equivalent to 'mcp-capi serve').
@@ -394,4 +394,4 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 ## Roadmap
 
-See our [GitHub Issues](https://github.com/giantswarm/mcp-capi/issues) for the complete roadmap and planned features. 
+See our [GitHub Issues](https://github.com/giantswarm/mcp-capi/issues) for the complete roadmap and planned features.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,7 +13,7 @@ var rootCmd = &cobra.Command{
 	Short: "MCP server for Cluster API operations",
 	Long: `mcp-capi is a Model Context Protocol (MCP) server that provides
 tools for interacting with Cluster API (CAPI) clusters. It offers various capabilities
-including cluster management, machine operations, scaling, and infrastructure 
+including cluster management, machine operations, scaling, and infrastructure
 provider management.
 
 When run without subcommands, it starts the MCP server (equivalent to 'mcp-capi serve').`,

--- a/cmd/selfupdate.go
+++ b/cmd/selfupdate.go
@@ -19,7 +19,7 @@ func newSelfUpdateCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "self-update",
 		Short: "Update mcp-capi to the latest version",
-		Long: `Checks for the latest release of mcp-capi on GitHub and 
+		Long: `Checks for the latest release of mcp-capi on GitHub and
 updates the current binary if a newer version is found.`,
 		RunE: runSelfUpdate,
 	}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,15 +66,15 @@ Similar patterns with provider-specific resources.
 graph TD
     Cluster --> InfrastructureCluster[Infrastructure Cluster<br/>e.g., AWSCluster]
     Cluster --> ControlPlane[Control Plane<br/>e.g., KubeadmControlPlane]
-    
+
     ControlPlane --> MachineSet[Control Plane Machines]
     MachineSet --> Machine1[Machine]
     MachineSet --> Machine2[Machine]
     MachineSet --> Machine3[Machine]
-    
+
     Machine1 --> InfraMachine1[Infrastructure Machine<br/>e.g., AWSMachine]
     Machine1 --> BootstrapConfig1[Bootstrap Config<br/>e.g., KubeadmConfig]
-    
+
     MachineDeployment --> MachineSetWorker[Worker MachineSet]
     MachineSetWorker --> WorkerMachine[Worker Machine]
 ```
@@ -127,4 +127,4 @@ This document will be expanded with:
 - ClusterClass and managed topologies
 - Upgrade strategies
 - Best practices
-- Troubleshooting guides 
+- Troubleshooting guides

--- a/docs/machine-tools.md
+++ b/docs/machine-tools.md
@@ -268,4 +268,4 @@ capi_cordon_node --node_name worker-node-1 --uncordon
 
 4. **Node Draining**: The current implementation only cordons nodes. Full pod eviction is not yet implemented - use kubectl drain for complete functionality.
 
-5. **Management vs Workload Cluster**: Most operations work on the management cluster. Node operations that require workload cluster access are limited. 
+5. **Management vs Workload Cluster**: Most operations work on the management cluster. Node operations that require workload cluster access are limited.

--- a/docs/provider-tools.md
+++ b/docs/provider-tools.md
@@ -226,4 +226,4 @@ The current implementations focus on:
 
 4. **Cost Optimization**: Tools to analyze and optimize cloud resource usage.
 
-5. **Multi-Cloud Operations**: Tools for managing clusters across multiple providers. 
+5. **Multi-Cloud Operations**: Tools for managing clusters across multiple providers.

--- a/pkg/capi/client.go
+++ b/pkg/capi/client.go
@@ -16,8 +16,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"             //nolint:staticcheck // CAPI v1beta1 required until v1beta2 migration
 	controlplanev1 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta1" //nolint:staticcheck // CAPI v1beta1 required until v1beta2 migration
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"                      //nolint:staticcheck // CAPI v1beta1 required until v1beta2 migration
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/capi/providers.go
+++ b/pkg/capi/providers.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"             //nolint:staticcheck // CAPI v1beta1 required until v1beta2 migration
 	controlplanev1 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta1" //nolint:staticcheck // CAPI v1beta1 required until v1beta2 migration
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"                      //nolint:staticcheck // CAPI v1beta1 required until v1beta2 migration
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/mcp/handlers/cluster.go
+++ b/pkg/mcp/handlers/cluster.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/giantswarm/mcp-capi/pkg/capi"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1" //nolint:staticcheck // CAPI v1beta1 required until v1beta2 migration
+
+	"github.com/giantswarm/mcp-capi/pkg/capi"
 )
 
 // createCreateClusterHandler creates a handler for creating new CAPI clusters

--- a/pkg/mcp/handlers/machine.go
+++ b/pkg/mcp/handlers/machine.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/giantswarm/mcp-capi/pkg/capi"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/giantswarm/mcp-capi/pkg/capi"
 )
 
 // createListMachinesHandler creates a handler for listing CAPI machines
@@ -94,8 +95,8 @@ func CreateListMachineDeploymentsHandler(serverCtx *ServerContext) server.ToolHa
 			content.WriteString(fmt.Sprintf("MachineDeployment: %s/%s\n", md.Namespace, md.Name))
 			content.WriteString(fmt.Sprintf("  Cluster: %s\n", md.Spec.ClusterName))
 			if md.Spec.Replicas != nil {
-			content.WriteString(fmt.Sprintf("  Replicas: %d\n", *md.Spec.Replicas))
-		}
+				content.WriteString(fmt.Sprintf("  Replicas: %d\n", *md.Spec.Replicas))
+			}
 			if md.Status.Replicas > 0 {
 				content.WriteString(fmt.Sprintf("  Status: %d ready / %d updated / %d available\n",
 					md.Status.ReadyReplicas,

--- a/pkg/mcp/handlers/provider_aws.go
+++ b/pkg/mcp/handlers/provider_aws.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/giantswarm/mcp-capi/pkg/capi"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/giantswarm/mcp-capi/pkg/capi"
 )
 
 // AWS Provider Tools

--- a/pkg/mcp/handlers/provider_azure_gcp.go
+++ b/pkg/mcp/handlers/provider_azure_gcp.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/giantswarm/mcp-capi/pkg/capi"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/giantswarm/mcp-capi/pkg/capi"
 )
 
 // Azure Provider Tools

--- a/pkg/mcp/handlers/provider_vsphere.go
+++ b/pkg/mcp/handlers/provider_vsphere.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/giantswarm/mcp-capi/pkg/capi"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1" //nolint:staticcheck // CAPI v1beta1 required until v1beta2 migration
+
+	"github.com/giantswarm/mcp-capi/pkg/capi"
 )
 
 // vSphere Provider Tools

--- a/pkg/mcp/handlers/types.go
+++ b/pkg/mcp/handlers/types.go
@@ -1,9 +1,10 @@
 package handlers
 
 import (
-	"github.com/giantswarm/mcp-capi/pkg/capi"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/giantswarm/mcp-capi/pkg/capi"
 )
 
 // ServerContext holds shared resources for the MCP server handlers.

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -8,9 +8,10 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/mark3labs/mcp-go/server"
+
 	"github.com/giantswarm/mcp-capi/pkg/capi"
 	"github.com/giantswarm/mcp-capi/pkg/mcp/handlers"
-	"github.com/mark3labs/mcp-go/server"
 )
 
 // Server represents an MCP CAPI server instance

--- a/scripts/download-crds.sh
+++ b/scripts/download-crds.sh
@@ -22,8 +22,10 @@ set -euo pipefail
 # Constants
 # =============================================================================
 
-readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-readonly PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+readonly PROJECT_ROOT
 readonly OUTPUT_DIR="${PROJECT_ROOT}/crds"
 readonly GITHUB_RAW_URL="https://raw.githubusercontent.com"
 
@@ -287,7 +289,7 @@ main() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --all)
-                providers=(${ALL_PROVIDERS})
+                read -r -a providers <<< "${ALL_PROVIDERS}"
                 shift
                 ;;
             --help|-h)


### PR DESCRIPTION
## Summary

Unblocks the stalled Align files PR #15 (open since 2025-06-26) by fixing pre-existing content issues and a CI drift that prevents that PR from passing checks.

- Apply pre-commit auto-fixer output: trailing whitespace stripped, final newlines normalized, `gofmt` + `goimports -local github.com/giantswarm/mcp-capi` applied across 28 files.
- `scripts/download-crds.sh`: fix three shellcheck warnings surfaced by the `shell-lint` hook — SC2155 (split `readonly VAR=\$(cmd)` into declare + assign so subshell failures aren't masked) and SC2206 (use `read -r -a` instead of unquoted word-splitting for array population).
- `.github/workflows/ci.yaml`: replace aggregate `make check` / `make release-dry-run` with the underlying commands (`yamllint`, `make lint`, `make test`, `goreleaser release --snapshot --clean --skip=announce,publish,validate`). Main's Makefile has `lint`/`test`; after PR #15 merges, the new `Makefile.gen.go.mk` will also provide them, but `check` and `release-dry-run` are dropped — so calling them directly keeps CI passing across the alignment cut-over.

Out of scope: the `golangci-lint not installed` error from the shared `giantswarm/github` pre-commit workflow (tracked in giantswarm/roadmap#4280).

## Test plan

- [ ] CI green on this PR (`CI Checks` / `Lint and Test`).
- [ ] After merge, re-run failed CI checks on #15 and confirm both `Lint and Test` and `pre-commit` hooks that are in-scope now pass on the merged preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)