### PR TITLE
ci: fix strict-lint violations exposed by alignment

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -15,7 +15,7 @@ func newVersionCmd() *cobra.Command {
 		Long:  `All software has versions. This is mcp-capi's.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// rootCmd.Version is expected to be set, typically in root.go during build time.
-			fmt.Fprintf(cmd.OutOrStdout(), "mcp-capi version %s\n", rootCmd.Version)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "mcp-capi version %s\n", rootCmd.Version)
 		},
 	}
 }

--- a/pkg/capi/client.go
+++ b/pkg/capi/client.go
@@ -625,8 +625,8 @@ func (c *Client) MoveCluster(ctx context.Context, opts MoveClusterOptions) (stri
 	// Create a YAML manifest for the move
 	var manifest strings.Builder
 	manifest.WriteString("# Cluster Move Manifest\n")
-	manifest.WriteString(fmt.Sprintf("# Source: %s/%s\n", opts.Namespace, opts.Name))
-	manifest.WriteString(fmt.Sprintf("# Target: %s/%s\n", targetNs, opts.Name))
+	fmt.Fprintf(&manifest, "# Source: %s/%s\n", opts.Namespace, opts.Name)
+	fmt.Fprintf(&manifest, "# Target: %s/%s\n", targetNs, opts.Name)
 	manifest.WriteString("# Apply this manifest to the target management cluster\n")
 	manifest.WriteString("---\n")
 
@@ -668,8 +668,8 @@ func (c *Client) BackupCluster(ctx context.Context, opts BackupClusterOptions) (
 	// Create backup manifest
 	var backup strings.Builder
 	backup.WriteString("# Cluster Backup\n")
-	backup.WriteString(fmt.Sprintf("# Cluster: %s/%s\n", opts.Namespace, opts.Name))
-	backup.WriteString(fmt.Sprintf("# Date: %s\n", fmt.Sprintf("%v", cluster.CreationTimestamp)))
+	fmt.Fprintf(&backup, "# Cluster: %s/%s\n", opts.Namespace, opts.Name)
+	fmt.Fprintf(&backup, "# Date: %v\n", cluster.CreationTimestamp)
 	backup.WriteString("# Resources included:\n")
 	backup.WriteString("# - Cluster\n")
 	backup.WriteString("# - Control Plane\n")
@@ -696,19 +696,13 @@ func (c *Client) BackupCluster(ctx context.Context, opts BackupClusterOptions) (
 }
 
 // Helper functions to map provider to API versions and kinds
+const infraAPIV1Beta1 = "infrastructure.cluster.x-k8s.io/v1beta1"
+
 func getInfraAPIVersion(provider string) string {
-	switch provider {
-	case "aws":
+	if provider == "aws" {
 		return "infrastructure.cluster.x-k8s.io/v1beta2"
-	case "azure":
-		return "infrastructure.cluster.x-k8s.io/v1beta1"
-	case "gcp":
-		return "infrastructure.cluster.x-k8s.io/v1beta1"
-	case "vsphere":
-		return "infrastructure.cluster.x-k8s.io/v1beta1"
-	default:
-		return "infrastructure.cluster.x-k8s.io/v1beta1"
 	}
+	return infraAPIV1Beta1
 }
 
 func getInfraKind(provider string) string {
@@ -771,7 +765,7 @@ func (c *Client) GetClusterHealth(ctx context.Context, namespace, name string) (
 
 		for _, machine := range machines.Items {
 			for _, condition := range machine.Status.Conditions {
-				if condition.Type == "Ready" && condition.Status == "True" {
+				if condition.Type == clusterv1.ReadyCondition && condition.Status == corev1.ConditionTrue {
 					readyMachines++
 					break
 				}
@@ -787,10 +781,10 @@ func (c *Client) GetClusterHealth(ctx context.Context, namespace, name string) (
 
 	// Check conditions for issues
 	for _, condition := range status.Conditions {
-		if condition.Status != "True" && condition.Severity == "Error" {
+		if condition.Status != corev1.ConditionTrue && condition.Severity == clusterv1.ConditionSeverityError {
 			health.Healthy = false
 			health.Issues = append(health.Issues, fmt.Sprintf("%s: %s", condition.Type, condition.Message))
-		} else if condition.Status != "True" && condition.Severity == "Warning" {
+		} else if condition.Status != corev1.ConditionTrue && condition.Severity == clusterv1.ConditionSeverityWarning {
 			health.Warnings = append(health.Warnings, fmt.Sprintf("%s: %s", condition.Type, condition.Message))
 		}
 	}

--- a/pkg/capi/providers.go
+++ b/pkg/capi/providers.go
@@ -3,6 +3,7 @@ package capi
 import (
 	"context"
 	"fmt"
+	"math"
 
 	controlplanev1 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta1" //nolint:staticcheck // CAPI v1beta1 required until v1beta2 migration
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"                      //nolint:staticcheck // CAPI v1beta1 required until v1beta2 migration
@@ -128,14 +129,17 @@ func (c *Client) ScaleControlPlane(ctx context.Context, namespace, name string, 
 
 // ScaleCluster scales either control plane or worker nodes of a cluster
 func (c *Client) ScaleCluster(ctx context.Context, namespace, clusterName, target string, replicas int, machineDeploymentName string) error {
+	if replicas < 0 || replicas > math.MaxInt32 {
+		return fmt.Errorf("replicas %d out of range for int32", replicas)
+	}
 	switch target {
 	case "controlplane":
-		return c.ScaleControlPlane(ctx, namespace, clusterName, int32(replicas))
+		return c.ScaleControlPlane(ctx, namespace, clusterName, int32(replicas)) //#nosec G115 -- bounded above
 	case "workers":
 		if machineDeploymentName == "" {
 			return fmt.Errorf("machineDeployment name is required when scaling workers")
 		}
-		return c.ScaleMachineDeployment(ctx, namespace, machineDeploymentName, int32(replicas))
+		return c.ScaleMachineDeployment(ctx, namespace, machineDeploymentName, int32(replicas)) //#nosec G115 -- bounded above
 	default:
 		return fmt.Errorf("invalid target: %s (must be 'controlplane' or 'workers')", target)
 	}

--- a/pkg/capi/utils.go
+++ b/pkg/capi/utils.go
@@ -11,6 +11,8 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"                      //nolint:staticcheck // CAPI v1beta1 required until v1beta2 migration
 )
 
+const kindKubeadmControlPlane = "KubeadmControlPlane"
+
 // ClusterStatus represents the status of a CAPI cluster
 type ClusterStatus struct {
 	Name              string
@@ -71,7 +73,7 @@ func (c *Client) GetClusterStatus(ctx context.Context, namespace, name string) (
 
 	// Get control plane version if available
 	if cluster.Spec.ControlPlaneRef != nil && status.Version == "" {
-		if cluster.Spec.ControlPlaneRef.Kind == "KubeadmControlPlane" {
+		if cluster.Spec.ControlPlaneRef.Kind == kindKubeadmControlPlane {
 			kcp, err := c.GetKubeadmControlPlane(ctx, namespace, cluster.Spec.ControlPlaneRef.Name)
 			if err == nil && kcp.Spec.Version != "" {
 				status.Version = kcp.Spec.Version
@@ -117,7 +119,7 @@ func (c *Client) GetClusterStatusFromList(ctx context.Context, cluster *clusterv
 
 	// Get control plane version if available
 	if cluster.Spec.ControlPlaneRef != nil && status.Version == "" {
-		if cluster.Spec.ControlPlaneRef.Kind == "KubeadmControlPlane" {
+		if cluster.Spec.ControlPlaneRef.Kind == kindKubeadmControlPlane {
 			kcp, err := c.GetKubeadmControlPlane(ctx, cluster.Namespace, cluster.Spec.ControlPlaneRef.Name)
 			if err == nil && kcp.Spec.Version != "" {
 				status.Version = kcp.Spec.Version
@@ -188,21 +190,21 @@ func GetControlPlaneStatus(kcp *controlplanev1.KubeadmControlPlane) string {
 func FormatClusterInfo(status *ClusterStatus) string {
 	var sb strings.Builder
 
-	sb.WriteString(fmt.Sprintf("Cluster: %s/%s\n", status.Namespace, status.Name))
-	sb.WriteString(fmt.Sprintf("Phase: %s\n", status.Phase))
-	sb.WriteString(fmt.Sprintf("Ready: %v\n", status.Ready))
+	fmt.Fprintf(&sb, "Cluster: %s/%s\n", status.Namespace, status.Name)
+	fmt.Fprintf(&sb, "Phase: %s\n", status.Phase)
+	fmt.Fprintf(&sb, "Ready: %v\n", status.Ready)
 	if status.Paused {
 		sb.WriteString("Paused: true\n")
 	}
-	sb.WriteString(fmt.Sprintf("Provider: %s\n", status.Provider))
-	sb.WriteString(fmt.Sprintf("Version: %s\n", status.Version))
-	sb.WriteString(fmt.Sprintf("Machines: %d/%d ready\n", status.ReadyMachines, status.TotalMachines))
+	fmt.Fprintf(&sb, "Provider: %s\n", status.Provider)
+	fmt.Fprintf(&sb, "Version: %s\n", status.Version)
+	fmt.Fprintf(&sb, "Machines: %d/%d ready\n", status.ReadyMachines, status.TotalMachines)
 
 	if userLabels := filterUserLabels(status.Labels); len(userLabels) > 0 {
 		sb.WriteString("\nLabels:\n")
 		keys := sortedKeys(userLabels)
 		for _, k := range keys {
-			sb.WriteString(fmt.Sprintf("  %s: %s\n", k, userLabels[k]))
+			fmt.Fprintf(&sb, "  %s: %s\n", k, userLabels[k])
 		}
 	}
 
@@ -210,16 +212,16 @@ func FormatClusterInfo(status *ClusterStatus) string {
 		sb.WriteString("\nAnnotations:\n")
 		keys := sortedKeys(status.Annotations)
 		for _, k := range keys {
-			sb.WriteString(fmt.Sprintf("  %s: %s\n", k, status.Annotations[k]))
+			fmt.Fprintf(&sb, "  %s: %s\n", k, status.Annotations[k])
 		}
 	}
 
 	if len(status.Conditions) > 0 {
 		sb.WriteString("\nConditions:\n")
 		for _, cond := range status.Conditions {
-			sb.WriteString(fmt.Sprintf("  %s: %s", cond.Type, cond.Status))
+			fmt.Fprintf(&sb, "  %s: %s", cond.Type, cond.Status)
 			if cond.Reason != "" {
-				sb.WriteString(fmt.Sprintf(" (%s)", cond.Reason))
+				fmt.Fprintf(&sb, " (%s)", cond.Reason)
 			}
 			sb.WriteString("\n")
 		}

--- a/pkg/mcp/handlers/cluster.go
+++ b/pkg/mcp/handlers/cluster.go
@@ -82,19 +82,19 @@ func CreateCreateClusterHandler(serverCtx *ServerContext) server.ToolHandlerFunc
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("✅ Cluster '%s' creation initiated successfully!\n\n", name))
+		fmt.Fprintf(&content, "✅ Cluster '%s' creation initiated successfully!\n\n", name)
 		content.WriteString("Cluster Details:\n")
-		content.WriteString(fmt.Sprintf("  Name: %s\n", cluster.Name))
-		content.WriteString(fmt.Sprintf("  Namespace: %s\n", cluster.Namespace))
-		content.WriteString(fmt.Sprintf("  Provider: %s\n", provider))
-		content.WriteString(fmt.Sprintf("  Kubernetes Version: %s\n", kubernetesVersion))
-		content.WriteString(fmt.Sprintf("  Control Plane Nodes: %d\n", controlPlaneCount))
-		content.WriteString(fmt.Sprintf("  Worker Nodes: %d\n", workerCount))
+		fmt.Fprintf(&content, "  Name: %s\n", cluster.Name)
+		fmt.Fprintf(&content, "  Namespace: %s\n", cluster.Namespace)
+		fmt.Fprintf(&content, "  Provider: %s\n", provider)
+		fmt.Fprintf(&content, "  Kubernetes Version: %s\n", kubernetesVersion)
+		fmt.Fprintf(&content, "  Control Plane Nodes: %d\n", controlPlaneCount)
+		fmt.Fprintf(&content, "  Worker Nodes: %d\n", workerCount)
 		if region != "" {
-			content.WriteString(fmt.Sprintf("  Region: %s\n", region))
+			fmt.Fprintf(&content, "  Region: %s\n", region)
 		}
 		if instanceType != "" {
-			content.WriteString(fmt.Sprintf("  Instance Type: %s\n", instanceType))
+			fmt.Fprintf(&content, "  Instance Type: %s\n", instanceType)
 		}
 		content.WriteString("\n⚠️  Note: This is a basic implementation that creates only the Cluster resource.\n")
 		content.WriteString("In a production setup, you would need to:\n")
@@ -176,7 +176,7 @@ func CreateListClustersHandler(serverCtx *ServerContext) server.ToolHandlerFunc 
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("Found %d clusters:\n\n", len(clusters.Items)))
+		fmt.Fprintf(&content, "Found %d clusters:\n\n", len(clusters.Items))
 
 		for i := range clusters.Items {
 			cluster := &clusters.Items[i]
@@ -242,7 +242,7 @@ func CreateGetClusterHandler(serverCtx *ServerContext) server.ToolHandlerFunc {
 				return nil, fmt.Errorf("failed to get cluster status: %w", err)
 			}
 			var content strings.Builder
-			content.WriteString(fmt.Sprintf("Note: No cluster named %q found. Matched cluster by label value:\n\n", name))
+			fmt.Fprintf(&content, "Note: No cluster named %q found. Matched cluster by label value:\n\n", name)
 			content.WriteString(capi.FormatClusterInfo(status))
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{
@@ -256,7 +256,7 @@ func CreateGetClusterHandler(serverCtx *ServerContext) server.ToolHandlerFunc {
 
 		// Multiple matches - list them for the user to disambiguate
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("No cluster named %q found, but %d clusters matched the term in their labels:\n\n", name, len(matched.Items)))
+		fmt.Fprintf(&content, "No cluster named %q found, but %d clusters matched the term in their labels:\n\n", name, len(matched.Items))
 		for _, cluster := range matched.Items {
 			status, err := serverCtx.CAPIClient.GetClusterStatus(ctx, cluster.Namespace, cluster.Name)
 			if err == nil {
@@ -331,22 +331,22 @@ func CreateClusterHealthHandler(serverCtx *ServerContext) server.ToolHandlerFunc
 
 		// Overall status
 		if health.Healthy {
-			content.WriteString(fmt.Sprintf("✅ Cluster %s/%s is HEALTHY\n\n", namespace, name))
+			fmt.Fprintf(&content, "✅ Cluster %s/%s is HEALTHY\n\n", namespace, name)
 		} else {
-			content.WriteString(fmt.Sprintf("❌ Cluster %s/%s is UNHEALTHY\n\n", namespace, name))
+			fmt.Fprintf(&content, "❌ Cluster %s/%s is UNHEALTHY\n\n", namespace, name)
 		}
 
 		// Component status
 		content.WriteString("Component Status:\n")
-		content.WriteString(fmt.Sprintf("  • Control Plane: %s\n", formatHealthStatus(health.ControlPlaneReady)))
-		content.WriteString(fmt.Sprintf("  • Infrastructure: %s\n", formatHealthStatus(health.InfraReady)))
-		content.WriteString(fmt.Sprintf("  • Worker Nodes: %s\n", formatHealthStatus(health.WorkersReady)))
+		fmt.Fprintf(&content, "  • Control Plane: %s\n", formatHealthStatus(health.ControlPlaneReady))
+		fmt.Fprintf(&content, "  • Infrastructure: %s\n", formatHealthStatus(health.InfraReady))
+		fmt.Fprintf(&content, "  • Worker Nodes: %s\n", formatHealthStatus(health.WorkersReady))
 
 		// Issues
 		if len(health.Issues) > 0 {
 			content.WriteString("\n🔴 Issues:\n")
 			for _, issue := range health.Issues {
-				content.WriteString(fmt.Sprintf("  • %s\n", issue))
+				fmt.Fprintf(&content, "  • %s\n", issue)
 			}
 		}
 
@@ -354,7 +354,7 @@ func CreateClusterHealthHandler(serverCtx *ServerContext) server.ToolHandlerFunc
 		if len(health.Warnings) > 0 {
 			content.WriteString("\n⚠️  Warnings:\n")
 			for _, warning := range health.Warnings {
-				content.WriteString(fmt.Sprintf("  • %s\n", warning))
+				fmt.Fprintf(&content, "  • %s\n", warning)
 			}
 		}
 
@@ -451,7 +451,7 @@ func CreateGetKubeconfigHandler(serverCtx *ServerContext) server.ToolHandlerFunc
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("Kubeconfig for cluster %s/%s:\n\n", namespace, name))
+		fmt.Fprintf(&content, "Kubeconfig for cluster %s/%s:\n\n", namespace, name)
 		content.WriteString("```yaml\n")
 		content.WriteString(kubeconfig)
 		content.WriteString("\n```\n\n")
@@ -489,7 +489,7 @@ func CreatePauseClusterHandler(serverCtx *ServerContext) server.ToolHandlerFunc 
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("✅ Cluster %s/%s has been paused\n\n", namespace, name))
+		fmt.Fprintf(&content, "✅ Cluster %s/%s has been paused\n\n", namespace, name)
 		content.WriteString("The cluster reconciliation has been stopped. This means:\n")
 		content.WriteString("- CAPI controllers will not make any changes to the cluster\n")
 		content.WriteString("- The cluster will not be updated or scaled automatically\n")
@@ -526,7 +526,7 @@ func CreateResumeClusterHandler(serverCtx *ServerContext) server.ToolHandlerFunc
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("✅ Cluster %s/%s has been resumed\n\n", namespace, name))
+		fmt.Fprintf(&content, "✅ Cluster %s/%s has been resumed\n\n", namespace, name)
 		content.WriteString("The cluster reconciliation has been restarted. This means:\n")
 		content.WriteString("- CAPI controllers will now reconcile the cluster normally\n")
 		content.WriteString("- Any pending updates or changes will be applied\n")
@@ -599,7 +599,7 @@ func CreateDeleteClusterHandler(serverCtx *ServerContext) server.ToolHandlerFunc
 			return nil, fmt.Errorf("failed to delete cluster: %w", err)
 		}
 
-		content.WriteString(fmt.Sprintf("\n✅ Cluster %s/%s deletion initiated successfully.\n\n", namespace, name))
+		fmt.Fprintf(&content, "\n✅ Cluster %s/%s deletion initiated successfully.\n\n", namespace, name)
 		content.WriteString("Note: The actual deletion process may take several minutes as:\n")
 		content.WriteString("- All cluster resources are being cleaned up\n")
 		content.WriteString("- Infrastructure resources are being deprovisioned\n")
@@ -647,11 +647,11 @@ func CreateUpgradeClusterHandler(serverCtx *ServerContext) server.ToolHandlerFun
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("🚀 Initiating cluster upgrade for %s/%s\n\n", namespace, name))
+		fmt.Fprintf(&content, "🚀 Initiating cluster upgrade for %s/%s\n\n", namespace, name)
 		content.WriteString("Current State:\n")
-		content.WriteString(fmt.Sprintf("  • Current Version: %s\n", status.Version))
-		content.WriteString(fmt.Sprintf("  • Target Version: %s\n", targetVersion))
-		content.WriteString(fmt.Sprintf("  • Upgrade Workers: %v\n\n", upgradeWorkers))
+		fmt.Fprintf(&content, "  • Current Version: %s\n", status.Version)
+		fmt.Fprintf(&content, "  • Target Version: %s\n", targetVersion)
+		fmt.Fprintf(&content, "  • Upgrade Workers: %v\n\n", upgradeWorkers)
 
 		// Perform the upgrade
 		opts := capi.UpgradeClusterOptions{
@@ -741,16 +741,16 @@ func CreateUpdateClusterHandler(serverCtx *ServerContext) server.ToolHandlerFunc
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("✅ Cluster %s/%s updated successfully!\n\n", namespace, name))
+		fmt.Fprintf(&content, "✅ Cluster %s/%s updated successfully!\n\n", namespace, name)
 
 		// Show what was updated
 		if len(labelMap) > 0 {
 			content.WriteString("Labels updated:\n")
 			for k, v := range labelMap {
 				if v == "" {
-					content.WriteString(fmt.Sprintf("  ✗ Removed: %s\n", k))
+					fmt.Fprintf(&content, "  ✗ Removed: %s\n", k)
 				} else {
-					content.WriteString(fmt.Sprintf("  ✓ Set: %s=%s\n", k, v))
+					fmt.Fprintf(&content, "  ✓ Set: %s=%s\n", k, v)
 				}
 			}
 			content.WriteString("\n")
@@ -760,9 +760,9 @@ func CreateUpdateClusterHandler(serverCtx *ServerContext) server.ToolHandlerFunc
 			content.WriteString("Annotations updated:\n")
 			for k, v := range annotationMap {
 				if v == "" {
-					content.WriteString(fmt.Sprintf("  ✗ Removed: %s\n", k))
+					fmt.Fprintf(&content, "  ✗ Removed: %s\n", k)
 				} else {
-					content.WriteString(fmt.Sprintf("  ✓ Set: %s=%s\n", k, v))
+					fmt.Fprintf(&content, "  ✓ Set: %s=%s\n", k, v)
 				}
 			}
 			content.WriteString("\n")
@@ -773,7 +773,7 @@ func CreateUpdateClusterHandler(serverCtx *ServerContext) server.ToolHandlerFunc
 		content.WriteString("Labels:\n")
 		if len(cluster.Labels) > 0 {
 			for k, v := range cluster.Labels {
-				content.WriteString(fmt.Sprintf("  %s: %s\n", k, v))
+				fmt.Fprintf(&content, "  %s: %s\n", k, v)
 			}
 		} else {
 			content.WriteString("  (none)\n")
@@ -782,7 +782,7 @@ func CreateUpdateClusterHandler(serverCtx *ServerContext) server.ToolHandlerFunc
 		content.WriteString("\nAnnotations:\n")
 		if len(cluster.Annotations) > 0 {
 			for k, v := range cluster.Annotations {
-				content.WriteString(fmt.Sprintf("  %s: %s\n", k, v))
+				fmt.Fprintf(&content, "  %s: %s\n", k, v)
 			}
 		} else {
 			content.WriteString("  (none)\n")
@@ -832,7 +832,7 @@ func CreateMoveClusterHandler(serverCtx *ServerContext) server.ToolHandlerFunc {
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("🚀 Cluster Move Preparation for %s/%s\n\n", namespace, name))
+		fmt.Fprintf(&content, "🚀 Cluster Move Preparation for %s/%s\n\n", namespace, name)
 
 		if dryRun {
 			content.WriteString("⚠️  DRY RUN MODE - No actual changes will be made\n\n")
@@ -846,18 +846,18 @@ func CreateMoveClusterHandler(serverCtx *ServerContext) server.ToolHandlerFunc {
 
 		content.WriteString("```bash\n")
 		content.WriteString("# Pause the cluster first\n")
-		content.WriteString(fmt.Sprintf("kubectl patch cluster %s -n %s --type merge -p '{\"spec\":{\"paused\":true}}'\n\n", name, namespace))
+		fmt.Fprintf(&content, "kubectl patch cluster %s -n %s --type merge -p '{\"spec\":{\"paused\":true}}'\n\n", name, namespace)
 
 		content.WriteString("# Move the cluster\n")
 		if targetKubeconfig != "" {
-			content.WriteString(fmt.Sprintf("clusterctl move --to-kubeconfig=%s", targetKubeconfig))
+			fmt.Fprintf(&content, "clusterctl move --to-kubeconfig=%s", targetKubeconfig)
 		} else {
 			content.WriteString("clusterctl move --to-kubeconfig=<target-kubeconfig>")
 		}
 		if targetNamespace != "" && targetNamespace != namespace {
-			content.WriteString(fmt.Sprintf(" --namespace %s --to-namespace %s", namespace, targetNamespace))
+			fmt.Fprintf(&content, " --namespace %s --to-namespace %s", namespace, targetNamespace)
 		} else {
-			content.WriteString(fmt.Sprintf(" --namespace %s", namespace))
+			fmt.Fprintf(&content, " --namespace %s", namespace)
 		}
 		content.WriteString("\n")
 		content.WriteString("```\n\n")
@@ -917,11 +917,11 @@ func CreateBackupClusterHandler(serverCtx *ServerContext) server.ToolHandlerFunc
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("📦 Cluster Backup for %s/%s\n\n", namespace, name))
+		fmt.Fprintf(&content, "📦 Cluster Backup for %s/%s\n\n", namespace, name)
 
 		content.WriteString("Backup Configuration:\n")
-		content.WriteString(fmt.Sprintf("  • Format: %s\n", outputFormat))
-		content.WriteString(fmt.Sprintf("  • Include Secrets: %v\n\n", includeSecrets))
+		fmt.Fprintf(&content, "  • Format: %s\n", outputFormat)
+		fmt.Fprintf(&content, "  • Include Secrets: %v\n\n", includeSecrets)
 
 		content.WriteString("📋 Backup Instructions:\n")
 		content.WriteString("1. Save the backup content below to a file\n")
@@ -949,8 +949,8 @@ func CreateBackupClusterHandler(serverCtx *ServerContext) server.ToolHandlerFunc
 		content.WriteString("\n```\n\n")
 
 		content.WriteString("💾 To save this backup:\n")
-		content.WriteString(fmt.Sprintf("1. Copy the content between the ``` markers\n"))
-		content.WriteString(fmt.Sprintf("2. Save to a file: cluster-%s-%s-backup.%s\n", namespace, name, outputFormat))
+		content.WriteString("1. Copy the content between the ``` markers\n")
+		fmt.Fprintf(&content, "2. Save to a file: cluster-%s-%s-backup.%s\n", namespace, name, outputFormat)
 		content.WriteString("3. Encrypt if it contains secrets\n")
 
 		return &mcp.CallToolResult{

--- a/pkg/mcp/handlers/machine.go
+++ b/pkg/mcp/handlers/machine.go
@@ -28,23 +28,23 @@ func CreateListMachinesHandler(serverCtx *ServerContext) server.ToolHandlerFunc 
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("Found %d machines", len(machines.Items)))
+		fmt.Fprintf(&content, "Found %d machines", len(machines.Items))
 		if clusterName != "" {
-			content.WriteString(fmt.Sprintf(" in cluster %s", clusterName))
+			fmt.Fprintf(&content, " in cluster %s", clusterName)
 		}
 		content.WriteString(":\n\n")
 
 		for _, machine := range machines.Items {
-			content.WriteString(fmt.Sprintf("Machine: %s/%s\n", machine.Namespace, machine.Name))
-			content.WriteString(fmt.Sprintf("  Cluster: %s\n", machine.Spec.ClusterName))
+			fmt.Fprintf(&content, "Machine: %s/%s\n", machine.Namespace, machine.Name)
+			fmt.Fprintf(&content, "  Cluster: %s\n", machine.Spec.ClusterName)
 			if machine.Status.Phase != "" {
-				content.WriteString(fmt.Sprintf("  Phase: %s\n", machine.Status.Phase))
+				fmt.Fprintf(&content, "  Phase: %s\n", machine.Status.Phase)
 			}
 			if machine.Status.NodeRef != nil {
-				content.WriteString(fmt.Sprintf("  Node: %s\n", machine.Status.NodeRef.Name))
+				fmt.Fprintf(&content, "  Node: %s\n", machine.Status.NodeRef.Name)
 			}
 			if machine.Spec.ProviderID != nil {
-				content.WriteString(fmt.Sprintf("  Provider ID: %s\n", *machine.Spec.ProviderID))
+				fmt.Fprintf(&content, "  Provider ID: %s\n", *machine.Spec.ProviderID)
 			}
 			// Check if machine has Ready condition
 			ready := false
@@ -54,7 +54,7 @@ func CreateListMachinesHandler(serverCtx *ServerContext) server.ToolHandlerFunc 
 					break
 				}
 			}
-			content.WriteString(fmt.Sprintf("  Ready: %v\n", ready))
+			fmt.Fprintf(&content, "  Ready: %v\n", ready)
 			content.WriteString("\n")
 		}
 
@@ -85,29 +85,29 @@ func CreateListMachineDeploymentsHandler(serverCtx *ServerContext) server.ToolHa
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("Found %d machine deployments", len(mds.Items)))
+		fmt.Fprintf(&content, "Found %d machine deployments", len(mds.Items))
 		if clusterName != "" {
-			content.WriteString(fmt.Sprintf(" in cluster %s", clusterName))
+			fmt.Fprintf(&content, " in cluster %s", clusterName)
 		}
 		content.WriteString(":\n\n")
 
 		for _, md := range mds.Items {
-			content.WriteString(fmt.Sprintf("MachineDeployment: %s/%s\n", md.Namespace, md.Name))
-			content.WriteString(fmt.Sprintf("  Cluster: %s\n", md.Spec.ClusterName))
+			fmt.Fprintf(&content, "MachineDeployment: %s/%s\n", md.Namespace, md.Name)
+			fmt.Fprintf(&content, "  Cluster: %s\n", md.Spec.ClusterName)
 			if md.Spec.Replicas != nil {
-				content.WriteString(fmt.Sprintf("  Replicas: %d\n", *md.Spec.Replicas))
+				fmt.Fprintf(&content, "  Replicas: %d\n", *md.Spec.Replicas)
 			}
 			if md.Status.Replicas > 0 {
-				content.WriteString(fmt.Sprintf("  Status: %d ready / %d updated / %d available\n",
+				fmt.Fprintf(&content, "  Status: %d ready / %d updated / %d available\n",
 					md.Status.ReadyReplicas,
 					md.Status.UpdatedReplicas,
-					md.Status.AvailableReplicas))
+					md.Status.AvailableReplicas)
 			}
 			if md.Status.Phase != "" {
-				content.WriteString(fmt.Sprintf("  Phase: %s\n", md.Status.Phase))
+				fmt.Fprintf(&content, "  Phase: %s\n", md.Status.Phase)
 			}
 			if md.Spec.Template.Spec.Version != nil {
-				content.WriteString(fmt.Sprintf("  Kubernetes Version: %s\n", *md.Spec.Template.Spec.Version))
+				fmt.Fprintf(&content, "  Kubernetes Version: %s\n", *md.Spec.Template.Spec.Version)
 			}
 			content.WriteString("\n")
 		}
@@ -142,53 +142,53 @@ func CreateGetMachineHandler(serverCtx *ServerContext) server.ToolHandlerFunc {
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("Machine: %s/%s\n\n", machine.Namespace, machine.Name))
+		fmt.Fprintf(&content, "Machine: %s/%s\n\n", machine.Namespace, machine.Name)
 
 		// Basic information
 		content.WriteString("Basic Information:\n")
-		content.WriteString(fmt.Sprintf("  Cluster: %s\n", machine.Spec.ClusterName))
+		fmt.Fprintf(&content, "  Cluster: %s\n", machine.Spec.ClusterName)
 		if machine.Status.Phase != "" {
-			content.WriteString(fmt.Sprintf("  Phase: %s\n", machine.Status.Phase))
+			fmt.Fprintf(&content, "  Phase: %s\n", machine.Status.Phase)
 		}
 		if machine.Spec.Version != nil {
-			content.WriteString(fmt.Sprintf("  Kubernetes Version: %s\n", *machine.Spec.Version))
+			fmt.Fprintf(&content, "  Kubernetes Version: %s\n", *machine.Spec.Version)
 		}
 		if machine.Spec.ProviderID != nil {
-			content.WriteString(fmt.Sprintf("  Provider ID: %s\n", *machine.Spec.ProviderID))
+			fmt.Fprintf(&content, "  Provider ID: %s\n", *machine.Spec.ProviderID)
 		}
 
 		// Node information
 		if machine.Status.NodeRef != nil {
-			content.WriteString(fmt.Sprintf("\nNode Information:\n"))
-			content.WriteString(fmt.Sprintf("  Node Name: %s\n", machine.Status.NodeRef.Name))
-			content.WriteString(fmt.Sprintf("  Node UID: %s\n", machine.Status.NodeRef.UID))
+			content.WriteString("\nNode Information:\n")
+			fmt.Fprintf(&content, "  Node Name: %s\n", machine.Status.NodeRef.Name)
+			fmt.Fprintf(&content, "  Node UID: %s\n", machine.Status.NodeRef.UID)
 		}
 
 		// Bootstrap information
 		if machine.Spec.Bootstrap.ConfigRef != nil {
-			content.WriteString(fmt.Sprintf("\nBootstrap:\n"))
-			content.WriteString(fmt.Sprintf("  Kind: %s\n", machine.Spec.Bootstrap.ConfigRef.Kind))
-			content.WriteString(fmt.Sprintf("  Name: %s\n", machine.Spec.Bootstrap.ConfigRef.Name))
+			content.WriteString("\nBootstrap:\n")
+			fmt.Fprintf(&content, "  Kind: %s\n", machine.Spec.Bootstrap.ConfigRef.Kind)
+			fmt.Fprintf(&content, "  Name: %s\n", machine.Spec.Bootstrap.ConfigRef.Name)
 		}
 
 		// Infrastructure information
 		if machine.Spec.InfrastructureRef.Kind != "" {
-			content.WriteString(fmt.Sprintf("\nInfrastructure:\n"))
-			content.WriteString(fmt.Sprintf("  Kind: %s\n", machine.Spec.InfrastructureRef.Kind))
-			content.WriteString(fmt.Sprintf("  Name: %s\n", machine.Spec.InfrastructureRef.Name))
+			content.WriteString("\nInfrastructure:\n")
+			fmt.Fprintf(&content, "  Kind: %s\n", machine.Spec.InfrastructureRef.Kind)
+			fmt.Fprintf(&content, "  Name: %s\n", machine.Spec.InfrastructureRef.Name)
 		}
 
 		// Conditions
 		if len(machine.Status.Conditions) > 0 {
 			content.WriteString("\nConditions:\n")
 			for _, condition := range machine.Status.Conditions {
-				content.WriteString(fmt.Sprintf("  - Type: %s\n", condition.Type))
-				content.WriteString(fmt.Sprintf("    Status: %s\n", condition.Status))
+				fmt.Fprintf(&content, "  - Type: %s\n", condition.Type)
+				fmt.Fprintf(&content, "    Status: %s\n", condition.Status)
 				if condition.Reason != "" {
-					content.WriteString(fmt.Sprintf("    Reason: %s\n", condition.Reason))
+					fmt.Fprintf(&content, "    Reason: %s\n", condition.Reason)
 				}
 				if condition.Message != "" {
-					content.WriteString(fmt.Sprintf("    Message: %s\n", condition.Message))
+					fmt.Fprintf(&content, "    Message: %s\n", condition.Message)
 				}
 			}
 		}
@@ -197,7 +197,7 @@ func CreateGetMachineHandler(serverCtx *ServerContext) server.ToolHandlerFunc {
 		if len(machine.Status.Addresses) > 0 {
 			content.WriteString("\nAddresses:\n")
 			for _, addr := range machine.Status.Addresses {
-				content.WriteString(fmt.Sprintf("  - Type: %s, Address: %s\n", addr.Type, addr.Address))
+				fmt.Fprintf(&content, "  - Type: %s, Address: %s\n", addr.Type, addr.Address)
 			}
 		}
 
@@ -238,13 +238,13 @@ func CreateDeleteMachineHandler(serverCtx *ServerContext) server.ToolHandlerFunc
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("✅ Successfully initiated deletion of machine %s/%s\n\n", namespace, name))
+		fmt.Fprintf(&content, "✅ Successfully initiated deletion of machine %s/%s\n\n", namespace, name)
 		content.WriteString("Note: Machine deletion is asynchronous. The machine will be:\n")
 		content.WriteString("1. Drained (if it has a node)\n")
 		content.WriteString("2. Removed from the cluster\n")
 		content.WriteString("3. Infrastructure resources cleaned up\n\n")
 		content.WriteString("Monitor deletion progress with:\n")
-		content.WriteString(fmt.Sprintf("  capi_get_machine --namespace %s --name %s\n", namespace, name))
+		fmt.Fprintf(&content, "  capi_get_machine --namespace %s --name %s\n", namespace, name)
 
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
@@ -286,11 +286,11 @@ func CreateRemediateMachineHandler(serverCtx *ServerContext) server.ToolHandlerF
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("🔧 Triggered remediation for machine %s/%s\n\n", namespace, name))
+		fmt.Fprintf(&content, "🔧 Triggered remediation for machine %s/%s\n\n", namespace, name)
 		content.WriteString("Current Machine Status:\n")
-		content.WriteString(fmt.Sprintf("  • Phase: %s\n", machine.Status.Phase))
+		fmt.Fprintf(&content, "  • Phase: %s\n", machine.Status.Phase)
 		if machine.Status.NodeRef != nil {
-			content.WriteString(fmt.Sprintf("  • Node: %s\n", machine.Status.NodeRef.Name))
+			fmt.Fprintf(&content, "  • Node: %s\n", machine.Status.NodeRef.Name)
 		}
 		content.WriteString("\nRemediation Process:\n")
 		content.WriteString("1. Machine will be marked for remediation\n")
@@ -300,7 +300,7 @@ func CreateRemediateMachineHandler(serverCtx *ServerContext) server.ToolHandlerF
 		content.WriteString("   - Node may be rebooted\n")
 		content.WriteString("   - Custom remediation may be applied\n\n")
 		content.WriteString("Monitor remediation progress with:\n")
-		content.WriteString(fmt.Sprintf("  capi_get_machine --namespace %s --name %s\n", namespace, name))
+		fmt.Fprintf(&content, "  capi_get_machine --namespace %s --name %s\n", namespace, name)
 
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
@@ -382,23 +382,23 @@ func CreateCreateMachineDeploymentHandler(serverCtx *ServerContext) server.ToolH
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("✅ Successfully created machine deployment %s/%s\n\n", namespace, name))
+		fmt.Fprintf(&content, "✅ Successfully created machine deployment %s/%s\n\n", namespace, name)
 		content.WriteString("Configuration:\n")
-		content.WriteString(fmt.Sprintf("  • Cluster: %s\n", clusterName))
-		content.WriteString(fmt.Sprintf("  • Replicas: %d\n", replicas))
-		content.WriteString(fmt.Sprintf("  • Version: %s\n", version))
-		content.WriteString(fmt.Sprintf("  • Infrastructure: %s/%s\n", infraKind, infraName))
-		content.WriteString(fmt.Sprintf("  • Bootstrap: %s/%s\n", bootstrapKind, bootstrapName))
+		fmt.Fprintf(&content, "  • Cluster: %s\n", clusterName)
+		fmt.Fprintf(&content, "  • Replicas: %d\n", replicas)
+		fmt.Fprintf(&content, "  • Version: %s\n", version)
+		fmt.Fprintf(&content, "  • Infrastructure: %s/%s\n", infraKind, infraName)
+		fmt.Fprintf(&content, "  • Bootstrap: %s/%s\n", bootstrapKind, bootstrapName)
 		if md.Spec.MinReadySeconds != nil {
-			content.WriteString(fmt.Sprintf("  • Min Ready Seconds: %d\n", *md.Spec.MinReadySeconds))
+			fmt.Fprintf(&content, "  • Min Ready Seconds: %d\n", *md.Spec.MinReadySeconds)
 		}
 		content.WriteString("\nNote: Before creating a MachineDeployment, ensure you have:\n")
 		content.WriteString("1. Created the infrastructure template (e.g., AWSMachineTemplate)\n")
 		content.WriteString("2. Created the bootstrap config template (e.g., KubeadmConfigTemplate)\n\n")
 		content.WriteString("Monitor the deployment with:\n")
-		content.WriteString(fmt.Sprintf("  capi_list_machines --cluster %s\n", clusterName))
+		fmt.Fprintf(&content, "  capi_list_machines --cluster %s\n", clusterName)
 		content.WriteString("\nScale the deployment with:\n")
-		content.WriteString(fmt.Sprintf("  capi_scale_machinedeployment --namespace %s --name %s --replicas <count>\n", namespace, name))
+		fmt.Fprintf(&content, "  capi_scale_machinedeployment --namespace %s --name %s --replicas <count>\n", namespace, name)
 
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
@@ -459,19 +459,19 @@ func CreateScaleMachineDeploymentHandler(serverCtx *ServerContext) server.ToolHa
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("✅ Successfully scaled machine deployment %s/%s\n\n", namespace, name))
+		fmt.Fprintf(&content, "✅ Successfully scaled machine deployment %s/%s\n\n", namespace, name)
 		content.WriteString("Scaling Operation:\n")
-		content.WriteString(fmt.Sprintf("  • Previous Replicas: %d\n", currentReplicas))
-		content.WriteString(fmt.Sprintf("  • New Replicas: %d\n", replicas))
+		fmt.Fprintf(&content, "  • Previous Replicas: %d\n", currentReplicas)
+		fmt.Fprintf(&content, "  • New Replicas: %d\n", replicas)
 
 		if replicas > currentReplicas {
-			content.WriteString(fmt.Sprintf("  • Action: Scaling UP by %d nodes\n", replicas-currentReplicas))
+			fmt.Fprintf(&content, "  • Action: Scaling UP by %d nodes\n", replicas-currentReplicas)
 			content.WriteString("\nNew nodes will be:\n")
 			content.WriteString("1. Provisioned by the infrastructure provider\n")
 			content.WriteString("2. Bootstrapped with Kubernetes\n")
 			content.WriteString("3. Joined to the cluster\n")
 		} else if replicas < currentReplicas {
-			content.WriteString(fmt.Sprintf("  • Action: Scaling DOWN by %d nodes\n", currentReplicas-replicas))
+			fmt.Fprintf(&content, "  • Action: Scaling DOWN by %d nodes\n", currentReplicas-replicas)
 			content.WriteString("\nNodes will be:\n")
 			content.WriteString("1. Cordoned to prevent new workloads\n")
 			content.WriteString("2. Drained to move existing workloads\n")
@@ -482,7 +482,7 @@ func CreateScaleMachineDeploymentHandler(serverCtx *ServerContext) server.ToolHa
 		}
 
 		content.WriteString("\nMonitor scaling progress with:\n")
-		content.WriteString(fmt.Sprintf("  capi_list_machines --namespace %s\n", namespace))
+		fmt.Fprintf(&content, "  capi_list_machines --namespace %s\n", namespace)
 
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
@@ -558,17 +558,17 @@ func CreateUpdateMachineDeploymentHandler(serverCtx *ServerContext) server.ToolH
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("✅ Successfully updated machine deployment %s/%s\n\n", namespace, name))
+		fmt.Fprintf(&content, "✅ Successfully updated machine deployment %s/%s\n\n", namespace, name)
 		content.WriteString("Updated Configuration:\n")
 
 		if opts.Version != nil {
-			content.WriteString(fmt.Sprintf("  • Version: %s\n", *opts.Version))
+			fmt.Fprintf(&content, "  • Version: %s\n", *opts.Version)
 		}
 		if opts.Replicas != nil {
-			content.WriteString(fmt.Sprintf("  • Replicas: %d\n", *opts.Replicas))
+			fmt.Fprintf(&content, "  • Replicas: %d\n", *opts.Replicas)
 		}
 		if opts.MinReadySeconds != nil {
-			content.WriteString(fmt.Sprintf("  • Min Ready Seconds: %d\n", *opts.MinReadySeconds))
+			fmt.Fprintf(&content, "  • Min Ready Seconds: %d\n", *opts.MinReadySeconds)
 		}
 		if len(opts.Labels) > 0 {
 			content.WriteString("  • Labels updated\n")
@@ -578,9 +578,9 @@ func CreateUpdateMachineDeploymentHandler(serverCtx *ServerContext) server.ToolH
 		}
 
 		content.WriteString("\nCurrent Status:\n")
-		content.WriteString(fmt.Sprintf("  • Ready Replicas: %d\n", md.Status.ReadyReplicas))
-		content.WriteString(fmt.Sprintf("  • Updated Replicas: %d\n", md.Status.UpdatedReplicas))
-		content.WriteString(fmt.Sprintf("  • Available Replicas: %d\n", md.Status.AvailableReplicas))
+		fmt.Fprintf(&content, "  • Ready Replicas: %d\n", md.Status.ReadyReplicas)
+		fmt.Fprintf(&content, "  • Updated Replicas: %d\n", md.Status.UpdatedReplicas)
+		fmt.Fprintf(&content, "  • Available Replicas: %d\n", md.Status.AvailableReplicas)
 
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
@@ -619,10 +619,10 @@ func CreateRolloutMachineDeploymentHandler(serverCtx *ServerContext) server.Tool
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("🔄 Successfully triggered rollout for machine deployment %s/%s\n\n", namespace, name))
+		fmt.Fprintf(&content, "🔄 Successfully triggered rollout for machine deployment %s/%s\n\n", namespace, name)
 
 		if reason != "" {
-			content.WriteString(fmt.Sprintf("Reason: %s\n\n", reason))
+			fmt.Fprintf(&content, "Reason: %s\n\n", reason)
 		}
 
 		content.WriteString("Rollout Process:\n")
@@ -632,8 +632,8 @@ func CreateRolloutMachineDeploymentHandler(serverCtx *ServerContext) server.Tool
 		content.WriteString("4. Health checks ensure machines are ready before proceeding\n\n")
 
 		content.WriteString("Monitor rollout progress with:\n")
-		content.WriteString(fmt.Sprintf("  capi_list_machines --namespace %s --cluster <cluster-name>\n", namespace))
-		content.WriteString(fmt.Sprintf("  capi_list_machinedeployments --namespace %s\n", namespace))
+		fmt.Fprintf(&content, "  capi_list_machines --namespace %s --cluster <cluster-name>\n", namespace)
+		fmt.Fprintf(&content, "  capi_list_machinedeployments --namespace %s\n", namespace)
 
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
@@ -662,33 +662,33 @@ func CreateListMachineSetsHandler(serverCtx *ServerContext) server.ToolHandlerFu
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("Found %d machine sets", len(machineSets.Items)))
+		fmt.Fprintf(&content, "Found %d machine sets", len(machineSets.Items))
 		if clusterName != "" {
-			content.WriteString(fmt.Sprintf(" in cluster %s", clusterName))
+			fmt.Fprintf(&content, " in cluster %s", clusterName)
 		}
 		content.WriteString(":\n\n")
 
 		for _, ms := range machineSets.Items {
-			content.WriteString(fmt.Sprintf("MachineSet: %s/%s\n", ms.Namespace, ms.Name))
-			content.WriteString(fmt.Sprintf("  Cluster: %s\n", ms.Spec.ClusterName))
+			fmt.Fprintf(&content, "MachineSet: %s/%s\n", ms.Namespace, ms.Name)
+			fmt.Fprintf(&content, "  Cluster: %s\n", ms.Spec.ClusterName)
 			if ms.Spec.Replicas != nil {
-				content.WriteString(fmt.Sprintf("  Replicas: %d\n", *ms.Spec.Replicas))
+				fmt.Fprintf(&content, "  Replicas: %d\n", *ms.Spec.Replicas)
 			}
-			content.WriteString(fmt.Sprintf("  Ready: %d/%d\n", ms.Status.ReadyReplicas, ms.Status.Replicas))
-			content.WriteString(fmt.Sprintf("  Available: %d\n", ms.Status.AvailableReplicas))
+			fmt.Fprintf(&content, "  Ready: %d/%d\n", ms.Status.ReadyReplicas, ms.Status.Replicas)
+			fmt.Fprintf(&content, "  Available: %d\n", ms.Status.AvailableReplicas)
 
 			// Show owner reference (usually MachineDeployment)
 			for _, owner := range ms.OwnerReferences {
 				if owner.Kind == "MachineDeployment" {
-					content.WriteString(fmt.Sprintf("  Owner: MachineDeployment/%s\n", owner.Name))
+					fmt.Fprintf(&content, "  Owner: MachineDeployment/%s\n", owner.Name)
 				}
 			}
 
 			// Show machine template
 			if ms.Spec.Template.Spec.InfrastructureRef.Name != "" {
-				content.WriteString(fmt.Sprintf("  Infrastructure: %s/%s\n",
+				fmt.Fprintf(&content, "  Infrastructure: %s/%s\n",
 					ms.Spec.Template.Spec.InfrastructureRef.Kind,
-					ms.Spec.Template.Spec.InfrastructureRef.Name))
+					ms.Spec.Template.Spec.InfrastructureRef.Name)
 			}
 			content.WriteString("\n")
 		}
@@ -723,48 +723,48 @@ func CreateGetMachineSetHandler(serverCtx *ServerContext) server.ToolHandlerFunc
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("MachineSet: %s/%s\n\n", ms.Namespace, ms.Name))
+		fmt.Fprintf(&content, "MachineSet: %s/%s\n\n", ms.Namespace, ms.Name)
 
 		// Basic information
 		content.WriteString("Basic Information:\n")
-		content.WriteString(fmt.Sprintf("  Cluster: %s\n", ms.Spec.ClusterName))
+		fmt.Fprintf(&content, "  Cluster: %s\n", ms.Spec.ClusterName)
 		if ms.Spec.Replicas != nil {
-			content.WriteString(fmt.Sprintf("  Desired Replicas: %d\n", *ms.Spec.Replicas))
+			fmt.Fprintf(&content, "  Desired Replicas: %d\n", *ms.Spec.Replicas)
 		}
 
 		// Status
 		content.WriteString("\nStatus:\n")
-		content.WriteString(fmt.Sprintf("  Total Replicas: %d\n", ms.Status.Replicas))
-		content.WriteString(fmt.Sprintf("  Ready Replicas: %d\n", ms.Status.ReadyReplicas))
-		content.WriteString(fmt.Sprintf("  Available Replicas: %d\n", ms.Status.AvailableReplicas))
+		fmt.Fprintf(&content, "  Total Replicas: %d\n", ms.Status.Replicas)
+		fmt.Fprintf(&content, "  Ready Replicas: %d\n", ms.Status.ReadyReplicas)
+		fmt.Fprintf(&content, "  Available Replicas: %d\n", ms.Status.AvailableReplicas)
 		if ms.Status.FailureReason != nil { //nolint:staticcheck // CAPI v1beta1 required until v1beta2 migration
-			content.WriteString(fmt.Sprintf("  Failure Reason: %s\n", *ms.Status.FailureReason)) //nolint:staticcheck // CAPI v1beta1 required until v1beta2 migration
+			fmt.Fprintf(&content, "  Failure Reason: %s\n", *ms.Status.FailureReason) //nolint:staticcheck // CAPI v1beta1 required until v1beta2 migration
 		}
 		if ms.Status.FailureMessage != nil { //nolint:staticcheck // CAPI v1beta1 required until v1beta2 migration
-			content.WriteString(fmt.Sprintf("  Failure Message: %s\n", *ms.Status.FailureMessage)) //nolint:staticcheck // CAPI v1beta1 required until v1beta2 migration
+			fmt.Fprintf(&content, "  Failure Message: %s\n", *ms.Status.FailureMessage) //nolint:staticcheck // CAPI v1beta1 required until v1beta2 migration
 		}
 
 		// Machine template
 		content.WriteString("\nMachine Template:\n")
 		if ms.Spec.Template.Spec.Version != nil {
-			content.WriteString(fmt.Sprintf("  Kubernetes Version: %s\n", *ms.Spec.Template.Spec.Version))
+			fmt.Fprintf(&content, "  Kubernetes Version: %s\n", *ms.Spec.Template.Spec.Version)
 		}
 		if ms.Spec.Template.Spec.InfrastructureRef.Name != "" {
-			content.WriteString(fmt.Sprintf("  Infrastructure: %s/%s\n",
+			fmt.Fprintf(&content, "  Infrastructure: %s/%s\n",
 				ms.Spec.Template.Spec.InfrastructureRef.Kind,
-				ms.Spec.Template.Spec.InfrastructureRef.Name))
+				ms.Spec.Template.Spec.InfrastructureRef.Name)
 		}
 		if ms.Spec.Template.Spec.Bootstrap.ConfigRef != nil {
-			content.WriteString(fmt.Sprintf("  Bootstrap: %s/%s\n",
+			fmt.Fprintf(&content, "  Bootstrap: %s/%s\n",
 				ms.Spec.Template.Spec.Bootstrap.ConfigRef.Kind,
-				ms.Spec.Template.Spec.Bootstrap.ConfigRef.Name))
+				ms.Spec.Template.Spec.Bootstrap.ConfigRef.Name)
 		}
 
 		// Owner references
 		if len(ms.OwnerReferences) > 0 {
 			content.WriteString("\nOwners:\n")
 			for _, owner := range ms.OwnerReferences {
-				content.WriteString(fmt.Sprintf("  - %s: %s\n", owner.Kind, owner.Name))
+				fmt.Fprintf(&content, "  - %s: %s\n", owner.Kind, owner.Name)
 			}
 		}
 
@@ -772,13 +772,13 @@ func CreateGetMachineSetHandler(serverCtx *ServerContext) server.ToolHandlerFunc
 		if len(ms.Status.Conditions) > 0 {
 			content.WriteString("\nConditions:\n")
 			for _, condition := range ms.Status.Conditions {
-				content.WriteString(fmt.Sprintf("  - Type: %s\n", condition.Type))
-				content.WriteString(fmt.Sprintf("    Status: %s\n", condition.Status))
+				fmt.Fprintf(&content, "  - Type: %s\n", condition.Type)
+				fmt.Fprintf(&content, "    Status: %s\n", condition.Status)
 				if condition.Reason != "" {
-					content.WriteString(fmt.Sprintf("    Reason: %s\n", condition.Reason))
+					fmt.Fprintf(&content, "    Reason: %s\n", condition.Reason)
 				}
 				if condition.Message != "" {
-					content.WriteString(fmt.Sprintf("    Message: %s\n", condition.Message))
+					fmt.Fprintf(&content, "    Message: %s\n", condition.Message)
 				}
 			}
 		}
@@ -832,7 +832,7 @@ func CreateDrainNodeHandler(serverCtx *ServerContext) server.ToolHandlerFunc {
 			if strings.Contains(err.Error(), "has been cordoned") {
 				var content strings.Builder
 				content.WriteString("⚠️  Node drain partially implemented\n\n")
-				content.WriteString(fmt.Sprintf("Node has been cordoned (marked as unschedulable)\n"))
+				content.WriteString("Node has been cordoned (marked as unschedulable)\n")
 				content.WriteString("\nFull drain implementation would:\n")
 				content.WriteString("1. List all pods on the node\n")
 				content.WriteString("2. Filter out DaemonSet pods if requested\n")
@@ -841,7 +841,7 @@ func CreateDrainNodeHandler(serverCtx *ServerContext) server.ToolHandlerFunc {
 				content.WriteString("5. Force delete pods that exceed grace period\n\n")
 				content.WriteString("For now, you can manually drain using kubectl:\n")
 				if nodeName != "" {
-					content.WriteString(fmt.Sprintf("  kubectl drain %s --ignore-daemonsets --delete-emptydir-data\n", nodeName))
+					fmt.Fprintf(&content, "  kubectl drain %s --ignore-daemonsets --delete-emptydir-data\n", nodeName)
 				}
 
 				return &mcp.CallToolResult{
@@ -859,11 +859,11 @@ func CreateDrainNodeHandler(serverCtx *ServerContext) server.ToolHandlerFunc {
 		var content strings.Builder
 		content.WriteString("✅ Successfully drained node\n\n")
 		content.WriteString("Drain Options Applied:\n")
-		content.WriteString(fmt.Sprintf("  • Ignore DaemonSets: %v\n", opts.IgnoreDaemonSets))
-		content.WriteString(fmt.Sprintf("  • Delete Local Data: %v\n", opts.DeleteLocalData))
-		content.WriteString(fmt.Sprintf("  • Force: %v\n", opts.Force))
+		fmt.Fprintf(&content, "  • Ignore DaemonSets: %v\n", opts.IgnoreDaemonSets)
+		fmt.Fprintf(&content, "  • Delete Local Data: %v\n", opts.DeleteLocalData)
+		fmt.Fprintf(&content, "  • Force: %v\n", opts.Force)
 		if opts.GracePeriodSeconds != nil {
-			content.WriteString(fmt.Sprintf("  • Grace Period: %d seconds\n", *opts.GracePeriodSeconds))
+			fmt.Fprintf(&content, "  • Grace Period: %d seconds\n", *opts.GracePeriodSeconds)
 		}
 		content.WriteString("\nThe node is now:\n")
 		content.WriteString("• Cordoned (no new pods will be scheduled)\n")
@@ -914,7 +914,7 @@ func CreateCordonNodeHandler(serverCtx *ServerContext) server.ToolHandlerFunc {
 			action = "uncordoned"
 		}
 
-		content.WriteString(fmt.Sprintf("✅ Successfully %s node\n\n", action))
+		fmt.Fprintf(&content, "✅ Successfully %s node\n\n", action)
 
 		if opts.Uncordon {
 			content.WriteString("The node is now:\n")
@@ -967,60 +967,60 @@ func CreateNodeStatusHandler(serverCtx *ServerContext) server.ToolHandlerFunc {
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("Node: %s\n\n", node.Name))
+		fmt.Fprintf(&content, "Node: %s\n\n", node.Name)
 
 		// Basic information
 		content.WriteString("Basic Information:\n")
-		content.WriteString(fmt.Sprintf("  UID: %s\n", node.UID))
-		content.WriteString(fmt.Sprintf("  Created: %s\n", node.CreationTimestamp))
-		content.WriteString(fmt.Sprintf("  Schedulable: %v\n", !node.Spec.Unschedulable))
+		fmt.Fprintf(&content, "  UID: %s\n", node.UID)
+		fmt.Fprintf(&content, "  Created: %s\n", node.CreationTimestamp)
+		fmt.Fprintf(&content, "  Schedulable: %v\n", !node.Spec.Unschedulable)
 		if node.Spec.ProviderID != "" {
-			content.WriteString(fmt.Sprintf("  Provider ID: %s\n", node.Spec.ProviderID))
+			fmt.Fprintf(&content, "  Provider ID: %s\n", node.Spec.ProviderID)
 		}
 
 		// Node info
 		info := node.Status.NodeInfo
 		content.WriteString("\nNode Info:\n")
-		content.WriteString(fmt.Sprintf("  OS: %s (%s)\n", info.OperatingSystem, info.OSImage))
-		content.WriteString(fmt.Sprintf("  Kernel: %s\n", info.KernelVersion))
-		content.WriteString(fmt.Sprintf("  Container Runtime: %s\n", info.ContainerRuntimeVersion))
-		content.WriteString(fmt.Sprintf("  Kubelet: %s\n", info.KubeletVersion))
-		content.WriteString(fmt.Sprintf("  Architecture: %s\n", info.Architecture))
+		fmt.Fprintf(&content, "  OS: %s (%s)\n", info.OperatingSystem, info.OSImage)
+		fmt.Fprintf(&content, "  Kernel: %s\n", info.KernelVersion)
+		fmt.Fprintf(&content, "  Container Runtime: %s\n", info.ContainerRuntimeVersion)
+		fmt.Fprintf(&content, "  Kubelet: %s\n", info.KubeletVersion)
+		fmt.Fprintf(&content, "  Architecture: %s\n", info.Architecture)
 
 		// Capacity and allocatable resources
 		content.WriteString("\nResources:\n")
 		content.WriteString("  Capacity:\n")
 		if cpu := node.Status.Capacity[v1.ResourceCPU]; !cpu.IsZero() {
-			content.WriteString(fmt.Sprintf("    CPU: %s\n", cpu.String()))
+			fmt.Fprintf(&content, "    CPU: %s\n", cpu.String())
 		}
 		if memory := node.Status.Capacity[v1.ResourceMemory]; !memory.IsZero() {
-			content.WriteString(fmt.Sprintf("    Memory: %s\n", memory.String()))
+			fmt.Fprintf(&content, "    Memory: %s\n", memory.String())
 		}
 		if pods := node.Status.Capacity[v1.ResourcePods]; !pods.IsZero() {
-			content.WriteString(fmt.Sprintf("    Pods: %s\n", pods.String()))
+			fmt.Fprintf(&content, "    Pods: %s\n", pods.String())
 		}
 
 		content.WriteString("  Allocatable:\n")
 		if cpu := node.Status.Allocatable[v1.ResourceCPU]; !cpu.IsZero() {
-			content.WriteString(fmt.Sprintf("    CPU: %s\n", cpu.String()))
+			fmt.Fprintf(&content, "    CPU: %s\n", cpu.String())
 		}
 		if memory := node.Status.Allocatable[v1.ResourceMemory]; !memory.IsZero() {
-			content.WriteString(fmt.Sprintf("    Memory: %s\n", memory.String()))
+			fmt.Fprintf(&content, "    Memory: %s\n", memory.String())
 		}
 		if pods := node.Status.Allocatable[v1.ResourcePods]; !pods.IsZero() {
-			content.WriteString(fmt.Sprintf("    Pods: %s\n", pods.String()))
+			fmt.Fprintf(&content, "    Pods: %s\n", pods.String())
 		}
 
 		// Conditions
 		content.WriteString("\nConditions:\n")
 		for _, condition := range node.Status.Conditions {
-			content.WriteString(fmt.Sprintf("  - Type: %s\n", condition.Type))
-			content.WriteString(fmt.Sprintf("    Status: %s\n", condition.Status))
+			fmt.Fprintf(&content, "  - Type: %s\n", condition.Type)
+			fmt.Fprintf(&content, "    Status: %s\n", condition.Status)
 			if condition.Reason != "" {
-				content.WriteString(fmt.Sprintf("    Reason: %s\n", condition.Reason))
+				fmt.Fprintf(&content, "    Reason: %s\n", condition.Reason)
 			}
 			if condition.Message != "" {
-				content.WriteString(fmt.Sprintf("    Message: %s\n", condition.Message))
+				fmt.Fprintf(&content, "    Message: %s\n", condition.Message)
 			}
 		}
 
@@ -1028,7 +1028,7 @@ func CreateNodeStatusHandler(serverCtx *ServerContext) server.ToolHandlerFunc {
 		if len(node.Status.Addresses) > 0 {
 			content.WriteString("\nAddresses:\n")
 			for _, addr := range node.Status.Addresses {
-				content.WriteString(fmt.Sprintf("  - %s: %s\n", addr.Type, addr.Address))
+				fmt.Fprintf(&content, "  - %s: %s\n", addr.Type, addr.Address)
 			}
 		}
 
@@ -1036,11 +1036,11 @@ func CreateNodeStatusHandler(serverCtx *ServerContext) server.ToolHandlerFunc {
 		if len(node.Spec.Taints) > 0 {
 			content.WriteString("\nTaints:\n")
 			for _, taint := range node.Spec.Taints {
-				content.WriteString(fmt.Sprintf("  - Key: %s\n", taint.Key))
+				fmt.Fprintf(&content, "  - Key: %s\n", taint.Key)
 				if taint.Value != "" {
-					content.WriteString(fmt.Sprintf("    Value: %s\n", taint.Value))
+					fmt.Fprintf(&content, "    Value: %s\n", taint.Value)
 				}
-				content.WriteString(fmt.Sprintf("    Effect: %s\n", taint.Effect))
+				fmt.Fprintf(&content, "    Effect: %s\n", taint.Effect)
 			}
 		}
 

--- a/pkg/mcp/handlers/provider_aws.go
+++ b/pkg/mcp/handlers/provider_aws.go
@@ -36,10 +36,10 @@ func CreateAWSListClustersHandler(serverCtx *ServerContext) server.ToolHandlerFu
 					cluster.Spec.InfrastructureRef.Kind == "AWSManagedCluster") {
 				awsClusterCount++
 
-				content.WriteString(fmt.Sprintf("Cluster: %s/%s\n", cluster.Namespace, cluster.Name))
-				content.WriteString(fmt.Sprintf("  Infrastructure: %s\n", cluster.Spec.InfrastructureRef.Kind))
-				content.WriteString(fmt.Sprintf("  Phase: %s\n", cluster.Status.Phase))
-				content.WriteString(fmt.Sprintf("  Ready: %v\n", cluster.Status.InfrastructureReady))
+				fmt.Fprintf(&content, "Cluster: %s/%s\n", cluster.Namespace, cluster.Name)
+				fmt.Fprintf(&content, "  Infrastructure: %s\n", cluster.Spec.InfrastructureRef.Kind)
+				fmt.Fprintf(&content, "  Phase: %s\n", cluster.Status.Phase)
+				fmt.Fprintf(&content, "  Ready: %v\n", cluster.Status.InfrastructureReady)
 
 				// Try to get provider information
 				provider, _ := serverCtx.CAPIClient.GetProviderForCluster(ctx, cluster.Namespace, cluster.Name)
@@ -54,7 +54,7 @@ func CreateAWSListClustersHandler(serverCtx *ServerContext) server.ToolHandlerFu
 		if awsClusterCount == 0 {
 			content.WriteString("No AWS clusters found.\n")
 		} else {
-			content.WriteString(fmt.Sprintf("Total AWS clusters: %d\n", awsClusterCount))
+			fmt.Fprintf(&content, "Total AWS clusters: %d\n", awsClusterCount)
 		}
 
 		return &mcp.CallToolResult{
@@ -95,28 +95,28 @@ func CreateAWSGetClusterHandler(serverCtx *ServerContext) server.ToolHandlerFunc
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("AWS Cluster: %s/%s\n\n", namespace, name))
+		fmt.Fprintf(&content, "AWS Cluster: %s/%s\n\n", namespace, name)
 
 		// Basic cluster info
 		content.WriteString("Cluster Information:\n")
-		content.WriteString(fmt.Sprintf("  Phase: %s\n", cluster.Status.Phase))
-		content.WriteString(fmt.Sprintf("  Infrastructure Ready: %v\n", cluster.Status.InfrastructureReady))
-		content.WriteString(fmt.Sprintf("  Control Plane Ready: %v\n", cluster.Status.ControlPlaneReady))
+		fmt.Fprintf(&content, "  Phase: %s\n", cluster.Status.Phase)
+		fmt.Fprintf(&content, "  Infrastructure Ready: %v\n", cluster.Status.InfrastructureReady)
+		fmt.Fprintf(&content, "  Control Plane Ready: %v\n", cluster.Status.ControlPlaneReady)
 
 		// Infrastructure reference
 		content.WriteString("\nInfrastructure:\n")
-		content.WriteString(fmt.Sprintf("  Kind: %s\n", cluster.Spec.InfrastructureRef.Kind))
-		content.WriteString(fmt.Sprintf("  Name: %s\n", cluster.Spec.InfrastructureRef.Name))
-		content.WriteString(fmt.Sprintf("  API Version: %s\n", cluster.Spec.InfrastructureRef.APIVersion))
+		fmt.Fprintf(&content, "  Kind: %s\n", cluster.Spec.InfrastructureRef.Kind)
+		fmt.Fprintf(&content, "  Name: %s\n", cluster.Spec.InfrastructureRef.Name)
+		fmt.Fprintf(&content, "  API Version: %s\n", cluster.Spec.InfrastructureRef.APIVersion)
 
 		// Network configuration
 		if cluster.Spec.ClusterNetwork != nil {
 			content.WriteString("\nNetwork Configuration:\n")
 			if cluster.Spec.ClusterNetwork.Pods != nil && len(cluster.Spec.ClusterNetwork.Pods.CIDRBlocks) > 0 {
-				content.WriteString(fmt.Sprintf("  Pod CIDR: %s\n", strings.Join(cluster.Spec.ClusterNetwork.Pods.CIDRBlocks, ", ")))
+				fmt.Fprintf(&content, "  Pod CIDR: %s\n", strings.Join(cluster.Spec.ClusterNetwork.Pods.CIDRBlocks, ", "))
 			}
 			if cluster.Spec.ClusterNetwork.Services != nil && len(cluster.Spec.ClusterNetwork.Services.CIDRBlocks) > 0 {
-				content.WriteString(fmt.Sprintf("  Service CIDR: %s\n", strings.Join(cluster.Spec.ClusterNetwork.Services.CIDRBlocks, ", ")))
+				fmt.Fprintf(&content, "  Service CIDR: %s\n", strings.Join(cluster.Spec.ClusterNetwork.Services.CIDRBlocks, ", "))
 			}
 		}
 
@@ -124,9 +124,9 @@ func CreateAWSGetClusterHandler(serverCtx *ServerContext) server.ToolHandlerFunc
 		if len(cluster.Status.Conditions) > 0 {
 			content.WriteString("\nConditions:\n")
 			for _, condition := range cluster.Status.Conditions {
-				content.WriteString(fmt.Sprintf("  - %s: %s", condition.Type, condition.Status))
+				fmt.Fprintf(&content, "  - %s: %s", condition.Type, condition.Status)
 				if condition.Reason != "" {
-					content.WriteString(fmt.Sprintf(" (%s)", condition.Reason))
+					fmt.Fprintf(&content, " (%s)", condition.Reason)
 				}
 				content.WriteString("\n")
 			}
@@ -160,7 +160,7 @@ func CreateAWSGetMachineTemplateHandler(serverCtx *ServerContext) server.ToolHan
 
 		if name != "" {
 			// Get specific machine template
-			content.WriteString(fmt.Sprintf("AWS Machine Template: %s/%s\n\n", namespace, name))
+			fmt.Fprintf(&content, "AWS Machine Template: %s/%s\n\n", namespace, name)
 			content.WriteString("Note: Direct access to AWSMachineTemplate requires the AWS provider CRDs.\n")
 			content.WriteString("In a full implementation, this would show:\n")
 			content.WriteString("  - Instance type\n")
@@ -171,7 +171,7 @@ func CreateAWSGetMachineTemplateHandler(serverCtx *ServerContext) server.ToolHan
 			content.WriteString("  - User data configuration\n")
 		} else {
 			// List all machine templates
-			content.WriteString(fmt.Sprintf("AWS Machine Templates in namespace %s:\n\n", namespace))
+			fmt.Fprintf(&content, "AWS Machine Templates in namespace %s:\n\n", namespace)
 
 			// In a real implementation, we would list AWSMachineTemplate resources
 			// For now, we'll check for machine deployments and their templates
@@ -184,8 +184,8 @@ func CreateAWSGetMachineTemplateHandler(serverCtx *ServerContext) server.ToolHan
 			for _, md := range mds.Items {
 				if md.Spec.Template.Spec.InfrastructureRef.Kind == "AWSMachineTemplate" {
 					awsTemplateCount++
-					content.WriteString(fmt.Sprintf("Template: %s (used by MachineDeployment: %s)\n",
-						md.Spec.Template.Spec.InfrastructureRef.Name, md.Name))
+					fmt.Fprintf(&content, "Template: %s (used by MachineDeployment: %s)\n",
+						md.Spec.Template.Spec.InfrastructureRef.Name, md.Name)
 				}
 			}
 

--- a/pkg/mcp/handlers/provider_azure_gcp.go
+++ b/pkg/mcp/handlers/provider_azure_gcp.go
@@ -36,10 +36,10 @@ func CreateAzureListClustersHandler(serverCtx *ServerContext) server.ToolHandler
 					cluster.Spec.InfrastructureRef.Kind == "AzureManagedCluster") {
 				azureClusterCount++
 
-				content.WriteString(fmt.Sprintf("Cluster: %s/%s\n", cluster.Namespace, cluster.Name))
-				content.WriteString(fmt.Sprintf("  Infrastructure: %s\n", cluster.Spec.InfrastructureRef.Kind))
-				content.WriteString(fmt.Sprintf("  Phase: %s\n", cluster.Status.Phase))
-				content.WriteString(fmt.Sprintf("  Ready: %v\n", cluster.Status.InfrastructureReady))
+				fmt.Fprintf(&content, "Cluster: %s/%s\n", cluster.Namespace, cluster.Name)
+				fmt.Fprintf(&content, "  Infrastructure: %s\n", cluster.Spec.InfrastructureRef.Kind)
+				fmt.Fprintf(&content, "  Phase: %s\n", cluster.Status.Phase)
+				fmt.Fprintf(&content, "  Ready: %v\n", cluster.Status.InfrastructureReady)
 
 				// Try to get provider information
 				provider, _ := serverCtx.CAPIClient.GetProviderForCluster(ctx, cluster.Namespace, cluster.Name)
@@ -54,7 +54,7 @@ func CreateAzureListClustersHandler(serverCtx *ServerContext) server.ToolHandler
 		if azureClusterCount == 0 {
 			content.WriteString("No Azure clusters found.\n")
 		} else {
-			content.WriteString(fmt.Sprintf("Total Azure clusters: %d\n", azureClusterCount))
+			fmt.Fprintf(&content, "Total Azure clusters: %d\n", azureClusterCount)
 		}
 
 		return &mcp.CallToolResult{
@@ -95,18 +95,18 @@ func CreateAzureGetClusterHandler(serverCtx *ServerContext) server.ToolHandlerFu
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("Azure Cluster: %s/%s\n\n", namespace, name))
+		fmt.Fprintf(&content, "Azure Cluster: %s/%s\n\n", namespace, name)
 
 		// Basic cluster info
 		content.WriteString("Cluster Information:\n")
-		content.WriteString(fmt.Sprintf("  Phase: %s\n", cluster.Status.Phase))
-		content.WriteString(fmt.Sprintf("  Infrastructure Ready: %v\n", cluster.Status.InfrastructureReady))
-		content.WriteString(fmt.Sprintf("  Control Plane Ready: %v\n", cluster.Status.ControlPlaneReady))
+		fmt.Fprintf(&content, "  Phase: %s\n", cluster.Status.Phase)
+		fmt.Fprintf(&content, "  Infrastructure Ready: %v\n", cluster.Status.InfrastructureReady)
+		fmt.Fprintf(&content, "  Control Plane Ready: %v\n", cluster.Status.ControlPlaneReady)
 
 		// Infrastructure reference
 		content.WriteString("\nInfrastructure:\n")
-		content.WriteString(fmt.Sprintf("  Kind: %s\n", cluster.Spec.InfrastructureRef.Kind))
-		content.WriteString(fmt.Sprintf("  Name: %s\n", cluster.Spec.InfrastructureRef.Name))
+		fmt.Fprintf(&content, "  Kind: %s\n", cluster.Spec.InfrastructureRef.Kind)
+		fmt.Fprintf(&content, "  Name: %s\n", cluster.Spec.InfrastructureRef.Name)
 
 		content.WriteString("\nNote: For detailed Azure infrastructure information (resource group, vnet, etc.),\n")
 		content.WriteString("you would need to query the AzureCluster resource directly.\n")
@@ -200,10 +200,10 @@ func CreateGCPListClustersHandler(serverCtx *ServerContext) server.ToolHandlerFu
 					cluster.Spec.InfrastructureRef.Kind == "GCPManagedCluster") {
 				gcpClusterCount++
 
-				content.WriteString(fmt.Sprintf("Cluster: %s/%s\n", cluster.Namespace, cluster.Name))
-				content.WriteString(fmt.Sprintf("  Infrastructure: %s\n", cluster.Spec.InfrastructureRef.Kind))
-				content.WriteString(fmt.Sprintf("  Phase: %s\n", cluster.Status.Phase))
-				content.WriteString(fmt.Sprintf("  Ready: %v\n", cluster.Status.InfrastructureReady))
+				fmt.Fprintf(&content, "Cluster: %s/%s\n", cluster.Namespace, cluster.Name)
+				fmt.Fprintf(&content, "  Infrastructure: %s\n", cluster.Spec.InfrastructureRef.Kind)
+				fmt.Fprintf(&content, "  Phase: %s\n", cluster.Status.Phase)
+				fmt.Fprintf(&content, "  Ready: %v\n", cluster.Status.InfrastructureReady)
 
 				// Try to get provider information
 				provider, _ := serverCtx.CAPIClient.GetProviderForCluster(ctx, cluster.Namespace, cluster.Name)
@@ -218,7 +218,7 @@ func CreateGCPListClustersHandler(serverCtx *ServerContext) server.ToolHandlerFu
 		if gcpClusterCount == 0 {
 			content.WriteString("No GCP clusters found.\n")
 		} else {
-			content.WriteString(fmt.Sprintf("Total GCP clusters: %d\n", gcpClusterCount))
+			fmt.Fprintf(&content, "Total GCP clusters: %d\n", gcpClusterCount)
 		}
 
 		return &mcp.CallToolResult{
@@ -259,18 +259,18 @@ func CreateGCPGetClusterHandler(serverCtx *ServerContext) server.ToolHandlerFunc
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("GCP Cluster: %s/%s\n\n", namespace, name))
+		fmt.Fprintf(&content, "GCP Cluster: %s/%s\n\n", namespace, name)
 
 		// Basic cluster info
 		content.WriteString("Cluster Information:\n")
-		content.WriteString(fmt.Sprintf("  Phase: %s\n", cluster.Status.Phase))
-		content.WriteString(fmt.Sprintf("  Infrastructure Ready: %v\n", cluster.Status.InfrastructureReady))
-		content.WriteString(fmt.Sprintf("  Control Plane Ready: %v\n", cluster.Status.ControlPlaneReady))
+		fmt.Fprintf(&content, "  Phase: %s\n", cluster.Status.Phase)
+		fmt.Fprintf(&content, "  Infrastructure Ready: %v\n", cluster.Status.InfrastructureReady)
+		fmt.Fprintf(&content, "  Control Plane Ready: %v\n", cluster.Status.ControlPlaneReady)
 
 		// Infrastructure reference
 		content.WriteString("\nInfrastructure:\n")
-		content.WriteString(fmt.Sprintf("  Kind: %s\n", cluster.Spec.InfrastructureRef.Kind))
-		content.WriteString(fmt.Sprintf("  Name: %s\n", cluster.Spec.InfrastructureRef.Name))
+		fmt.Fprintf(&content, "  Kind: %s\n", cluster.Spec.InfrastructureRef.Kind)
+		fmt.Fprintf(&content, "  Name: %s\n", cluster.Spec.InfrastructureRef.Name)
 
 		content.WriteString("\nNote: For detailed GCP infrastructure information (VPC, firewall rules, etc.),\n")
 		content.WriteString("you would need to query the GCPCluster resource directly.\n")

--- a/pkg/mcp/handlers/provider_generic.go
+++ b/pkg/mcp/handlers/provider_generic.go
@@ -46,9 +46,9 @@ func CreateListInfrastructureProvidersHandler(serverCtx *ServerContext) server.T
 		}
 
 		for _, provider := range providers {
-			content.WriteString(fmt.Sprintf("Provider: %s\n", provider.Name))
-			content.WriteString(fmt.Sprintf("  API Version: %s\n", provider.APIVersion))
-			content.WriteString(fmt.Sprintf("  Description: %s\n", provider.Description))
+			fmt.Fprintf(&content, "Provider: %s\n", provider.Name)
+			fmt.Fprintf(&content, "  API Version: %s\n", provider.APIVersion)
+			fmt.Fprintf(&content, "  Description: %s\n", provider.Description)
 			content.WriteString("\n")
 		}
 
@@ -76,7 +76,7 @@ func CreateGetProviderConfigHandler(serverCtx *ServerContext) server.ToolHandler
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("Configuration for %s Provider:\n\n", strings.ToUpper(provider)))
+		fmt.Fprintf(&content, "Configuration for %s Provider:\n\n", strings.ToUpper(provider))
 
 		switch strings.ToLower(provider) {
 		case "aws":

--- a/pkg/mcp/handlers/provider_vsphere.go
+++ b/pkg/mcp/handlers/provider_vsphere.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1" //nolint:staticcheck // CAPI v1beta1 required until v1beta2 migration
 
 	"github.com/giantswarm/mcp-capi/pkg/capi"
 )
@@ -36,10 +35,10 @@ func CreateVSphereListClustersHandler(serverCtx *ServerContext) server.ToolHandl
 				cluster.Spec.InfrastructureRef.Kind == "VSphereCluster" {
 				vsphereClusterCount++
 
-				content.WriteString(fmt.Sprintf("Cluster: %s/%s\n", cluster.Namespace, cluster.Name))
-				content.WriteString(fmt.Sprintf("  Infrastructure: %s\n", cluster.Spec.InfrastructureRef.Kind))
-				content.WriteString(fmt.Sprintf("  Phase: %s\n", cluster.Status.Phase))
-				content.WriteString(fmt.Sprintf("  Ready: %v\n", cluster.Status.InfrastructureReady))
+				fmt.Fprintf(&content, "Cluster: %s/%s\n", cluster.Namespace, cluster.Name)
+				fmt.Fprintf(&content, "  Infrastructure: %s\n", cluster.Spec.InfrastructureRef.Kind)
+				fmt.Fprintf(&content, "  Phase: %s\n", cluster.Status.Phase)
+				fmt.Fprintf(&content, "  Ready: %v\n", cluster.Status.InfrastructureReady)
 
 				// Try to get provider information
 				provider, _ := serverCtx.CAPIClient.GetProviderForCluster(ctx, cluster.Namespace, cluster.Name)
@@ -54,7 +53,7 @@ func CreateVSphereListClustersHandler(serverCtx *ServerContext) server.ToolHandl
 		if vsphereClusterCount == 0 {
 			content.WriteString("No vSphere clusters found.\n")
 		} else {
-			content.WriteString(fmt.Sprintf("Total vSphere clusters: %d\n", vsphereClusterCount))
+			fmt.Fprintf(&content, "Total vSphere clusters: %d\n", vsphereClusterCount)
 		}
 
 		return &mcp.CallToolResult{
@@ -94,18 +93,18 @@ func CreateVSphereGetClusterHandler(serverCtx *ServerContext) server.ToolHandler
 		}
 
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("vSphere Cluster: %s/%s\n\n", namespace, name))
+		fmt.Fprintf(&content, "vSphere Cluster: %s/%s\n\n", namespace, name)
 
 		// Basic cluster info
 		content.WriteString("Cluster Information:\n")
-		content.WriteString(fmt.Sprintf("  Phase: %s\n", cluster.Status.Phase))
-		content.WriteString(fmt.Sprintf("  Infrastructure Ready: %v\n", cluster.Status.InfrastructureReady))
-		content.WriteString(fmt.Sprintf("  Control Plane Ready: %v\n", cluster.Status.ControlPlaneReady))
+		fmt.Fprintf(&content, "  Phase: %s\n", cluster.Status.Phase)
+		fmt.Fprintf(&content, "  Infrastructure Ready: %v\n", cluster.Status.InfrastructureReady)
+		fmt.Fprintf(&content, "  Control Plane Ready: %v\n", cluster.Status.ControlPlaneReady)
 
 		// Infrastructure reference
 		content.WriteString("\nInfrastructure:\n")
-		content.WriteString(fmt.Sprintf("  Kind: %s\n", cluster.Spec.InfrastructureRef.Kind))
-		content.WriteString(fmt.Sprintf("  Name: %s\n", cluster.Spec.InfrastructureRef.Name))
+		fmt.Fprintf(&content, "  Kind: %s\n", cluster.Spec.InfrastructureRef.Kind)
+		fmt.Fprintf(&content, "  Name: %s\n", cluster.Spec.InfrastructureRef.Name)
 
 		content.WriteString("\nNote: For detailed vSphere infrastructure information (datacenter, datastore, etc.),\n")
 		content.WriteString("you would need to query the VSphereCluster resource directly.\n")
@@ -149,19 +148,3 @@ func CreateVSphereManageVMsHandler(serverCtx *ServerContext) server.ToolHandlerF
 	}
 }
 
-// Helper function to filter clusters by provider
-func filterClustersByProvider(clusters *clusterv1.ClusterList, providerKinds []string) []*clusterv1.Cluster {
-	var filtered []*clusterv1.Cluster
-	for i := range clusters.Items {
-		cluster := &clusters.Items[i]
-		if cluster.Spec.InfrastructureRef != nil {
-			for _, kind := range providerKinds {
-				if cluster.Spec.InfrastructureRef.Kind == kind {
-					filtered = append(filtered, cluster)
-					break
-				}
-			}
-		}
-	}
-	return filtered
-}

--- a/pkg/mcp/transport.go
+++ b/pkg/mcp/transport.go
@@ -38,14 +38,10 @@ func RunStdioServer(mcpSrv *mcpserver.MCPServer, stdin io.Reader, stdout io.Writ
 	}()
 
 	// Wait for server completion
-	select {
-	case err := <-serverDone:
-		if err != nil {
-			return fmt.Errorf("server stopped with error: %w", err)
-		} else {
-			fmt.Println("Server stopped normally")
-		}
+	if err := <-serverDone; err != nil {
+		return fmt.Errorf("server stopped with error: %w", err)
 	}
+	fmt.Println("Server stopped normally")
 
 	fmt.Println("Server gracefully stopped")
 	return nil

--- a/test/harness/golden.go
+++ b/test/harness/golden.go
@@ -44,7 +44,7 @@ func compareWithGoldenNormalized(text, goldenPath string, normalizers []Normaliz
 		return updateGoldenFile(normalized, goldenPath)
 	}
 
-	expected, err := os.ReadFile(goldenPath)
+	expected, err := os.ReadFile(goldenPath) //#nosec G304 -- test helper reads test fixtures
 	if err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("golden file %s does not exist (run tests with UPDATE_GOLDEN=true to create it)", goldenPath)

--- a/test/harness/golden_test.go
+++ b/test/harness/golden_test.go
@@ -250,7 +250,7 @@ func TestUpdateGoldenFile(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		got, err := os.ReadFile(goldenPath)
+		got, err := os.ReadFile(goldenPath) //#nosec G304 -- test reads file just written to t.TempDir()
 		if err != nil {
 			t.Fatalf("failed to read written file: %v", err)
 		}
@@ -270,7 +270,7 @@ func TestUpdateGoldenFile(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		got, err := os.ReadFile(goldenPath)
+		got, err := os.ReadFile(goldenPath) //#nosec G304 -- test reads file just written to t.TempDir()
 		if err != nil {
 			t.Fatalf("failed to read written file: %v", err)
 		}
@@ -294,7 +294,7 @@ func TestUpdateGoldenFile(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		got, err := os.ReadFile(goldenPath)
+		got, err := os.ReadFile(goldenPath) //#nosec G304 -- test reads file just written to t.TempDir()
 		if err != nil {
 			t.Fatalf("failed to read written file: %v", err)
 		}

--- a/test/harness/testenv.go
+++ b/test/harness/testenv.go
@@ -325,6 +325,8 @@ func (o *clusterCreateOptions) needsStatusUpdate() bool {
 	return o.hasStatus || o.phase != "" || len(o.conditions) > 0 || o.controlPlaneReady != nil || o.infraReady != nil
 }
 
+const infraAPIV1Beta1 = "infrastructure.cluster.x-k8s.io/v1beta1"
+
 // providerInfraRef returns the APIVersion and Kind for a provider's infrastructure reference.
 // Returns empty strings for unknown providers (no InfrastructureRef is set).
 func providerInfraRef(provider string) (apiVersion, kind string) {
@@ -332,13 +334,13 @@ func providerInfraRef(provider string) (apiVersion, kind string) {
 	case "aws":
 		return "infrastructure.cluster.x-k8s.io/v1beta2", "AWSCluster"
 	case "azure":
-		return "infrastructure.cluster.x-k8s.io/v1beta1", "AzureCluster"
+		return infraAPIV1Beta1, "AzureCluster"
 	case "gcp":
-		return "infrastructure.cluster.x-k8s.io/v1beta1", "GCPCluster"
+		return infraAPIV1Beta1, "GCPCluster"
 	case "vsphere":
-		return "infrastructure.cluster.x-k8s.io/v1beta1", "VSphereCluster"
+		return infraAPIV1Beta1, "VSphereCluster"
 	case "vcd":
-		return "infrastructure.cluster.x-k8s.io/v1beta1", "VCDCluster"
+		return infraAPIV1Beta1, "VCDCluster"
 	default:
 		return "", ""
 	}

--- a/test/integration/capi_aws_get_cluster_test.go
+++ b/test/integration/capi_aws_get_cluster_test.go
@@ -11,7 +11,7 @@ func TestCapiAWSGetCluster(t *testing.T) {
 
 	t.Run("should get AWS cluster details", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -25,7 +25,7 @@ func TestCapiAWSGetCluster(t *testing.T) {
 
 	t.Run("should error for non-AWS cluster", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -39,7 +39,7 @@ func TestCapiAWSGetCluster(t *testing.T) {
 
 	t.Run("should error when cluster not found", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -62,7 +62,7 @@ func TestCapiAWSGetCluster(t *testing.T) {
 
 	t.Run("should error when name is missing", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -74,7 +74,7 @@ func TestCapiAWSGetCluster(t *testing.T) {
 
 	t.Run("should accept AWSManagedCluster kind", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -88,7 +88,7 @@ func TestCapiAWSGetCluster(t *testing.T) {
 
 	t.Run("should show cluster conditions", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -104,7 +104,7 @@ func TestCapiAWSGetCluster(t *testing.T) {
 
 	t.Run("should error for cluster with nil infrastructure ref", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -118,7 +118,7 @@ func TestCapiAWSGetCluster(t *testing.T) {
 
 	t.Run("should show cluster network with pod and service CIDRs", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).

--- a/test/integration/capi_aws_get_machine_template_test.go
+++ b/test/integration/capi_aws_get_machine_template_test.go
@@ -11,7 +11,7 @@ func TestCapiAWSGetMachineTemplate(t *testing.T) {
 
 	t.Run("should list machine templates", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -28,7 +28,7 @@ func TestCapiAWSGetMachineTemplate(t *testing.T) {
 
 	t.Run("should show no templates when none exist", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -40,7 +40,7 @@ func TestCapiAWSGetMachineTemplate(t *testing.T) {
 
 	t.Run("should get specific template by name", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -62,7 +62,7 @@ func TestCapiAWSGetMachineTemplate(t *testing.T) {
 
 	t.Run("should only list AWSMachineTemplate templates", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).

--- a/test/integration/capi_aws_list_clusters_test.go
+++ b/test/integration/capi_aws_list_clusters_test.go
@@ -11,7 +11,7 @@ func TestCapiAWSListClusters(t *testing.T) {
 
 	t.Run("should list AWS clusters", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -25,7 +25,7 @@ func TestCapiAWSListClusters(t *testing.T) {
 
 	t.Run("should show no AWS clusters when none exist", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -37,7 +37,7 @@ func TestCapiAWSListClusters(t *testing.T) {
 
 	t.Run("should list AWSManagedCluster clusters", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -50,7 +50,7 @@ func TestCapiAWSListClusters(t *testing.T) {
 
 	t.Run("should filter by namespace", func(t *testing.T) {
 		t.Parallel()
-		ns1 := "test-clusters"
+		ns1 := testNamespace
 		ns2 := "other-clusters"
 
 		harness.New(t).
@@ -66,7 +66,7 @@ func TestCapiAWSListClusters(t *testing.T) {
 
 	t.Run("should skip clusters with nil infrastructure ref", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -80,7 +80,7 @@ func TestCapiAWSListClusters(t *testing.T) {
 
 	t.Run("should list multiple AWS clusters with different phases", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).

--- a/test/integration/capi_azure_get_cluster_test.go
+++ b/test/integration/capi_azure_get_cluster_test.go
@@ -11,7 +11,7 @@ func TestCapiAzureGetCluster(t *testing.T) {
 
 	t.Run("should get Azure cluster details", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -25,7 +25,7 @@ func TestCapiAzureGetCluster(t *testing.T) {
 
 	t.Run("should error for non-Azure cluster", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -39,7 +39,7 @@ func TestCapiAzureGetCluster(t *testing.T) {
 
 	t.Run("should error when cluster not found", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -62,7 +62,7 @@ func TestCapiAzureGetCluster(t *testing.T) {
 
 	t.Run("should error when name is missing", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -74,7 +74,7 @@ func TestCapiAzureGetCluster(t *testing.T) {
 
 	t.Run("should accept AzureManagedCluster kind", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -88,7 +88,7 @@ func TestCapiAzureGetCluster(t *testing.T) {
 
 	t.Run("should error for cluster with nil infrastructure ref", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).

--- a/test/integration/capi_azure_list_clusters_test.go
+++ b/test/integration/capi_azure_list_clusters_test.go
@@ -11,7 +11,7 @@ func TestCapiAzureListClusters(t *testing.T) {
 
 	t.Run("should list Azure clusters", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -24,7 +24,7 @@ func TestCapiAzureListClusters(t *testing.T) {
 
 	t.Run("should show no Azure clusters", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -36,7 +36,7 @@ func TestCapiAzureListClusters(t *testing.T) {
 
 	t.Run("should list AzureManagedCluster clusters", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -49,7 +49,7 @@ func TestCapiAzureListClusters(t *testing.T) {
 
 	t.Run("should filter out non-Azure clusters", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).

--- a/test/integration/capi_backup_cluster_test.go
+++ b/test/integration/capi_backup_cluster_test.go
@@ -24,14 +24,14 @@ func TestCapiBackupCluster(t *testing.T) {
 
 		harness.New(t).
 			ToolCall("capi_backup_cluster").
-			WithArg("namespace", "test-clusters").
+			WithArg("namespace", testNamespace).
 			AssertError("missing_name.golden").
 			Execute()
 	})
 
 	t.Run("returns error for non-existent cluster", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -44,7 +44,7 @@ func TestCapiBackupCluster(t *testing.T) {
 
 	t.Run("backs up cluster with default settings", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -58,7 +58,7 @@ func TestCapiBackupCluster(t *testing.T) {
 
 	t.Run("backs up cluster with JSON output format", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -73,7 +73,7 @@ func TestCapiBackupCluster(t *testing.T) {
 
 	t.Run("backs up cluster with secrets included", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -88,7 +88,7 @@ func TestCapiBackupCluster(t *testing.T) {
 
 	t.Run("backs up cluster with JSON format and secrets", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -104,7 +104,7 @@ func TestCapiBackupCluster(t *testing.T) {
 
 	t.Run("should exclude secrets when include_secrets is false", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -122,7 +122,7 @@ func TestCapiBackupCluster(t *testing.T) {
 
 	t.Run("should error on invalid output format", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -137,7 +137,7 @@ func TestCapiBackupCluster(t *testing.T) {
 
 	t.Run("should backup cluster with rich state", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).

--- a/test/integration/capi_cluster_health_test.go
+++ b/test/integration/capi_cluster_health_test.go
@@ -13,7 +13,7 @@ func TestCapiClusterHealth(t *testing.T) {
 
 	t.Run("returns error for non-existent cluster", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -26,7 +26,7 @@ func TestCapiClusterHealth(t *testing.T) {
 
 	t.Run("returns healthy status for basic cluster", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -40,7 +40,7 @@ func TestCapiClusterHealth(t *testing.T) {
 
 	t.Run("returns unhealthy status when control plane is not ready", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -58,7 +58,7 @@ func TestCapiClusterHealth(t *testing.T) {
 
 	t.Run("returns unhealthy status with partial machine readiness", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -72,7 +72,7 @@ func TestCapiClusterHealth(t *testing.T) {
 
 	t.Run("returns healthy status with all machines ready and provisioned phase", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -88,7 +88,7 @@ func TestCapiClusterHealth(t *testing.T) {
 
 	t.Run("returns warning for non-provisioned phase", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -112,7 +112,7 @@ func TestCapiClusterHealth(t *testing.T) {
 
 	t.Run("returns error when name argument is missing", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -124,7 +124,7 @@ func TestCapiClusterHealth(t *testing.T) {
 
 	t.Run("shows infra-specific recommendations when CP ready but infra not ready", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -141,7 +141,7 @@ func TestCapiClusterHealth(t *testing.T) {
 
 	t.Run("shows CP-specific recommendations when CP not ready but infra ready", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -158,7 +158,7 @@ func TestCapiClusterHealth(t *testing.T) {
 
 	t.Run("shows only worker recommendations when CP and infra ready but no machines", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -175,7 +175,7 @@ func TestCapiClusterHealth(t *testing.T) {
 
 	t.Run("shows condition with Error severity in Issues section", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -191,7 +191,7 @@ func TestCapiClusterHealth(t *testing.T) {
 
 	t.Run("shows condition with Warning severity in Warnings section", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -207,7 +207,7 @@ func TestCapiClusterHealth(t *testing.T) {
 
 	t.Run("reports workers not ready when zero machines exist", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -225,7 +225,7 @@ func TestCapiClusterHealth(t *testing.T) {
 
 	t.Run("returns warning for Failed phase", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -239,7 +239,7 @@ func TestCapiClusterHealth(t *testing.T) {
 
 	t.Run("returns warning for Deleting phase", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -253,7 +253,7 @@ func TestCapiClusterHealth(t *testing.T) {
 
 	t.Run("does not generate phase warning for empty phase", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -268,7 +268,7 @@ func TestCapiClusterHealth(t *testing.T) {
 
 	t.Run("shows both issues and warnings for combined error and warning conditions", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -285,7 +285,7 @@ func TestCapiClusterHealth(t *testing.T) {
 
 	t.Run("shows all recommendation sections when CP infra and workers are all not ready", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -303,7 +303,7 @@ func TestCapiClusterHealth(t *testing.T) {
 
 	t.Run("should show multiple error severity conditions", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -320,7 +320,7 @@ func TestCapiClusterHealth(t *testing.T) {
 
 	t.Run("should show provisioning phase warning", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).

--- a/test/integration/capi_cluster_status_test.go
+++ b/test/integration/capi_cluster_status_test.go
@@ -32,7 +32,7 @@ func TestCapiClusterStatus(t *testing.T) {
 
 	t.Run("returns error for non-existent cluster", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -45,7 +45,7 @@ func TestCapiClusterStatus(t *testing.T) {
 
 	t.Run("gets status of a basic cluster", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -59,7 +59,7 @@ func TestCapiClusterStatus(t *testing.T) {
 
 	t.Run("gets status with provider and phase", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -73,7 +73,7 @@ func TestCapiClusterStatus(t *testing.T) {
 
 	t.Run("gets status with version from topology", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -87,7 +87,7 @@ func TestCapiClusterStatus(t *testing.T) {
 
 	t.Run("gets status with partial machine readiness", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -101,7 +101,7 @@ func TestCapiClusterStatus(t *testing.T) {
 
 	t.Run("gets status with all machines ready", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -115,7 +115,7 @@ func TestCapiClusterStatus(t *testing.T) {
 
 	t.Run("gets status with no machines ready", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -129,7 +129,7 @@ func TestCapiClusterStatus(t *testing.T) {
 
 	t.Run("gets status with conditions", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -147,7 +147,7 @@ func TestCapiClusterStatus(t *testing.T) {
 
 	t.Run("gets status with unhealthy conditions", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -165,7 +165,7 @@ func TestCapiClusterStatus(t *testing.T) {
 
 	t.Run("gets status with version from control plane", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -182,7 +182,7 @@ func TestCapiClusterStatus(t *testing.T) {
 
 	t.Run("gets status with version precedence over control plane", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -200,7 +200,7 @@ func TestCapiClusterStatus(t *testing.T) {
 
 	t.Run("gets status with all properties", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -218,7 +218,7 @@ func TestCapiClusterStatus(t *testing.T) {
 
 	t.Run("gets status with unknown infrastructure provider", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -234,7 +234,7 @@ func TestCapiClusterStatus(t *testing.T) {
 
 	t.Run("gets status with non-kubeadm control plane", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -251,7 +251,7 @@ func TestCapiClusterStatus(t *testing.T) {
 
 	t.Run("gets status with missing control plane resource", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -269,7 +269,7 @@ func TestCapiClusterStatus(t *testing.T) {
 	for _, provider := range providers {
 		t.Run(fmt.Sprintf("gets %s cluster status with all properties", provider), func(t *testing.T) {
 			t.Parallel()
-			namespace := "test-clusters"
+			namespace := testNamespace
 
 			harness.New(t).
 				CreateNamespace(namespace).
@@ -287,7 +287,7 @@ func TestCapiClusterStatus(t *testing.T) {
 
 		t.Run(fmt.Sprintf("gets %s cluster status with version from control plane", provider), func(t *testing.T) {
 			t.Parallel()
-			namespace := "test-clusters"
+			namespace := testNamespace
 
 			harness.New(t).
 				CreateNamespace(namespace).
@@ -305,7 +305,7 @@ func TestCapiClusterStatus(t *testing.T) {
 
 	t.Run("should show paused cluster", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -319,7 +319,7 @@ func TestCapiClusterStatus(t *testing.T) {
 
 	t.Run("should show cluster with labels and annotations", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -336,7 +336,7 @@ func TestCapiClusterStatus(t *testing.T) {
 
 	t.Run("gets status with mixed conditions ready true cp false", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -353,7 +353,7 @@ func TestCapiClusterStatus(t *testing.T) {
 
 	t.Run("gets status with mixed conditions ready false infra true", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -370,7 +370,7 @@ func TestCapiClusterStatus(t *testing.T) {
 
 	t.Run("gets status with no conditions", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -385,7 +385,7 @@ func TestCapiClusterStatus(t *testing.T) {
 
 	t.Run("gets status with nil control plane ref", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -402,7 +402,7 @@ func TestCapiClusterStatus(t *testing.T) {
 
 	t.Run("shows status for cluster with nil infrastructure ref", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).

--- a/test/integration/capi_gcp_get_cluster_test.go
+++ b/test/integration/capi_gcp_get_cluster_test.go
@@ -11,7 +11,7 @@ func TestCapiGCPGetCluster(t *testing.T) {
 
 	t.Run("should get GCP cluster details", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -25,7 +25,7 @@ func TestCapiGCPGetCluster(t *testing.T) {
 
 	t.Run("should error for non-GCP cluster", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -39,7 +39,7 @@ func TestCapiGCPGetCluster(t *testing.T) {
 
 	t.Run("should error when cluster not found", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -62,7 +62,7 @@ func TestCapiGCPGetCluster(t *testing.T) {
 
 	t.Run("should error when name is missing", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -74,7 +74,7 @@ func TestCapiGCPGetCluster(t *testing.T) {
 
 	t.Run("should accept GCPManagedCluster kind", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -88,7 +88,7 @@ func TestCapiGCPGetCluster(t *testing.T) {
 
 	t.Run("should error for cluster with nil infrastructure ref", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).

--- a/test/integration/capi_gcp_list_clusters_test.go
+++ b/test/integration/capi_gcp_list_clusters_test.go
@@ -11,7 +11,7 @@ func TestCapiGCPListClusters(t *testing.T) {
 
 	t.Run("should list GCP clusters", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -24,7 +24,7 @@ func TestCapiGCPListClusters(t *testing.T) {
 
 	t.Run("should show no GCP clusters", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -36,7 +36,7 @@ func TestCapiGCPListClusters(t *testing.T) {
 
 	t.Run("should list GCPManagedCluster clusters", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).

--- a/test/integration/capi_get_cluster_test.go
+++ b/test/integration/capi_get_cluster_test.go
@@ -32,7 +32,7 @@ func TestCapiGetCluster(t *testing.T) {
 
 	t.Run("returns error for non-existent cluster", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -45,7 +45,7 @@ func TestCapiGetCluster(t *testing.T) {
 
 	t.Run("gets a basic cluster", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -59,7 +59,7 @@ func TestCapiGetCluster(t *testing.T) {
 
 	t.Run("gets cluster with provider and phase", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -73,7 +73,7 @@ func TestCapiGetCluster(t *testing.T) {
 
 	t.Run("gets cluster with version from topology", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -87,7 +87,7 @@ func TestCapiGetCluster(t *testing.T) {
 
 	t.Run("gets cluster with partial machine readiness", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -101,7 +101,7 @@ func TestCapiGetCluster(t *testing.T) {
 
 	t.Run("gets cluster with all machines ready", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -115,7 +115,7 @@ func TestCapiGetCluster(t *testing.T) {
 
 	t.Run("gets cluster with no machines ready", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -129,7 +129,7 @@ func TestCapiGetCluster(t *testing.T) {
 
 	t.Run("gets cluster with conditions", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -147,7 +147,7 @@ func TestCapiGetCluster(t *testing.T) {
 
 	t.Run("gets cluster with unhealthy conditions", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -165,7 +165,7 @@ func TestCapiGetCluster(t *testing.T) {
 
 	t.Run("gets cluster with version from control plane", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -182,7 +182,7 @@ func TestCapiGetCluster(t *testing.T) {
 
 	t.Run("gets cluster with version precedence over control plane", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -200,7 +200,7 @@ func TestCapiGetCluster(t *testing.T) {
 
 	t.Run("gets cluster with all properties", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -218,7 +218,7 @@ func TestCapiGetCluster(t *testing.T) {
 
 	t.Run("gets cluster with unknown infrastructure provider", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -234,7 +234,7 @@ func TestCapiGetCluster(t *testing.T) {
 
 	t.Run("gets cluster with non-kubeadm control plane", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -251,7 +251,7 @@ func TestCapiGetCluster(t *testing.T) {
 
 	t.Run("gets cluster with missing control plane resource", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -269,7 +269,7 @@ func TestCapiGetCluster(t *testing.T) {
 	for _, provider := range providers {
 		t.Run(fmt.Sprintf("gets %s cluster with all properties", provider), func(t *testing.T) {
 			t.Parallel()
-			namespace := "test-clusters"
+			namespace := testNamespace
 
 			harness.New(t).
 				CreateNamespace(namespace).
@@ -287,7 +287,7 @@ func TestCapiGetCluster(t *testing.T) {
 
 		t.Run(fmt.Sprintf("gets %s cluster with version from control plane", provider), func(t *testing.T) {
 			t.Parallel()
-			namespace := "test-clusters"
+			namespace := testNamespace
 
 			harness.New(t).
 				CreateNamespace(namespace).
@@ -305,7 +305,7 @@ func TestCapiGetCluster(t *testing.T) {
 
 	t.Run("should show paused cluster", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -319,7 +319,7 @@ func TestCapiGetCluster(t *testing.T) {
 
 	t.Run("should show cluster with labels and annotations", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -336,7 +336,7 @@ func TestCapiGetCluster(t *testing.T) {
 
 	t.Run("gets cluster with mixed conditions", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -354,7 +354,7 @@ func TestCapiGetCluster(t *testing.T) {
 
 	t.Run("gets cluster with no conditions", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -369,7 +369,7 @@ func TestCapiGetCluster(t *testing.T) {
 
 	t.Run("gets cluster with nil control plane ref", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -385,7 +385,7 @@ func TestCapiGetCluster(t *testing.T) {
 
 	t.Run("gets cluster with nil infrastructure ref", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).

--- a/test/integration/capi_get_kubeconfig_test.go
+++ b/test/integration/capi_get_kubeconfig_test.go
@@ -11,7 +11,7 @@ func TestCapiGetKubeconfig(t *testing.T) {
 
 	t.Run("returns error for non-existent cluster kubeconfig", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -24,7 +24,7 @@ func TestCapiGetKubeconfig(t *testing.T) {
 
 	t.Run("retrieves kubeconfig successfully", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		kubeconfigData := `apiVersion: v1
 kind: Config
@@ -58,7 +58,7 @@ users:
 
 	t.Run("retrieves kubeconfig from data key", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		kubeconfigData := `apiVersion: v1
 kind: Config
@@ -91,7 +91,7 @@ clusters:
 
 	t.Run("returns error without name argument", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -103,7 +103,7 @@ clusters:
 
 	t.Run("returns error when secret has no recognized key", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -119,7 +119,7 @@ clusters:
 
 	t.Run("returns empty kubeconfig when value key is empty", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -135,7 +135,7 @@ clusters:
 
 	t.Run("prefers value key over data key", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).

--- a/test/integration/capi_get_machine_test.go
+++ b/test/integration/capi_get_machine_test.go
@@ -11,7 +11,7 @@ func TestCapiGetMachine(t *testing.T) {
 
 	t.Run("gets an existing machine", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -25,7 +25,7 @@ func TestCapiGetMachine(t *testing.T) {
 
 	t.Run("gets a machine without node ref", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -39,7 +39,7 @@ func TestCapiGetMachine(t *testing.T) {
 
 	t.Run("returns error for non-existent machine", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -52,7 +52,7 @@ func TestCapiGetMachine(t *testing.T) {
 
 	t.Run("returns error when namespace argument is missing", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -64,7 +64,7 @@ func TestCapiGetMachine(t *testing.T) {
 
 	t.Run("returns error when name argument is missing", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -76,7 +76,7 @@ func TestCapiGetMachine(t *testing.T) {
 
 	t.Run("gets machine from cluster with multiple machines", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -90,7 +90,7 @@ func TestCapiGetMachine(t *testing.T) {
 
 	t.Run("gets machine with all optional fields", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -116,7 +116,7 @@ func TestCapiGetMachine(t *testing.T) {
 
 	t.Run("gets machine with nil bootstrap config ref", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -134,7 +134,7 @@ func TestCapiGetMachine(t *testing.T) {
 
 	t.Run("gets machine with empty infrastructure ref kind", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -152,7 +152,7 @@ func TestCapiGetMachine(t *testing.T) {
 
 	t.Run("gets machine with nil version", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -170,7 +170,7 @@ func TestCapiGetMachine(t *testing.T) {
 
 	t.Run("gets machine with no conditions", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -190,7 +190,7 @@ func TestCapiGetMachine(t *testing.T) {
 
 	t.Run("gets machine with condition without reason and message", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).

--- a/test/integration/capi_get_machineset_test.go
+++ b/test/integration/capi_get_machineset_test.go
@@ -11,7 +11,7 @@ func TestCapiGetMachineSet(t *testing.T) {
 
 	t.Run("returns error for non-existent machine set", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -24,7 +24,7 @@ func TestCapiGetMachineSet(t *testing.T) {
 
 	t.Run("returns error without namespace argument", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -36,7 +36,7 @@ func TestCapiGetMachineSet(t *testing.T) {
 
 	t.Run("returns error without name argument", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -48,7 +48,7 @@ func TestCapiGetMachineSet(t *testing.T) {
 
 	t.Run("gets a basic machine set", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -64,7 +64,7 @@ func TestCapiGetMachineSet(t *testing.T) {
 
 	t.Run("gets machine set with version", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -80,7 +80,7 @@ func TestCapiGetMachineSet(t *testing.T) {
 
 	t.Run("gets machine set with infrastructure reference", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -97,7 +97,7 @@ func TestCapiGetMachineSet(t *testing.T) {
 
 	t.Run("gets machine set with bootstrap reference", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -114,7 +114,7 @@ func TestCapiGetMachineSet(t *testing.T) {
 
 	t.Run("gets machine set with owner reference", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -131,7 +131,7 @@ func TestCapiGetMachineSet(t *testing.T) {
 
 	t.Run("gets machine set with all properties", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -151,7 +151,7 @@ func TestCapiGetMachineSet(t *testing.T) {
 
 	t.Run("gets machine set with zero ready replicas", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -167,7 +167,7 @@ func TestCapiGetMachineSet(t *testing.T) {
 
 	t.Run("gets machine set with failure reason", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -184,7 +184,7 @@ func TestCapiGetMachineSet(t *testing.T) {
 
 	t.Run("gets machine set with failure message", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -201,7 +201,7 @@ func TestCapiGetMachineSet(t *testing.T) {
 
 	t.Run("gets machine set with both failure reason and message", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -219,7 +219,7 @@ func TestCapiGetMachineSet(t *testing.T) {
 
 	t.Run("gets machine set with condition", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -237,7 +237,7 @@ func TestCapiGetMachineSet(t *testing.T) {
 
 	t.Run("gets machine set with condition without reason and message", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -255,7 +255,7 @@ func TestCapiGetMachineSet(t *testing.T) {
 
 	t.Run("gets machine set with multiple conditions", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -274,7 +274,7 @@ func TestCapiGetMachineSet(t *testing.T) {
 
 	t.Run("should handle nil replicas", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).

--- a/test/integration/capi_list_clusters_test.go
+++ b/test/integration/capi_list_clusters_test.go
@@ -14,7 +14,7 @@ func TestCapiListClusters(t *testing.T) {
 
 	t.Run("lists multiple clusters", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -27,7 +27,7 @@ func TestCapiListClusters(t *testing.T) {
 
 	t.Run("lists clusters with metadata", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -40,7 +40,7 @@ func TestCapiListClusters(t *testing.T) {
 
 	t.Run("filters clusters by namespace", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 		otherNamespace := "other-clusters"
 
 		harness.New(t).
@@ -59,7 +59,7 @@ func TestCapiListClusters(t *testing.T) {
 
 	t.Run("handles empty namespace", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -71,7 +71,7 @@ func TestCapiListClusters(t *testing.T) {
 
 	t.Run("lists single cluster", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -84,7 +84,7 @@ func TestCapiListClusters(t *testing.T) {
 
 	t.Run("lists clusters without namespace argument", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -96,7 +96,7 @@ func TestCapiListClusters(t *testing.T) {
 
 	t.Run("should show paused cluster in list", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -110,7 +110,7 @@ func TestCapiListClusters(t *testing.T) {
 
 	t.Run("lists mixed providers in same namespace", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -125,7 +125,7 @@ func TestCapiListClusters(t *testing.T) {
 
 	t.Run("lists cluster with unknown infrastructure provider", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -140,7 +140,7 @@ func TestCapiListClusters(t *testing.T) {
 
 	t.Run("lists cluster with non-kubeadm control plane", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -156,7 +156,7 @@ func TestCapiListClusters(t *testing.T) {
 
 	t.Run("lists cluster with missing control plane resource", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -172,7 +172,7 @@ func TestCapiListClusters(t *testing.T) {
 
 	t.Run("lists clusters across all namespaces", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 		namespace1 := "multi-ns-1"
 		namespace2 := "multi-ns-2"
 
@@ -192,7 +192,7 @@ func TestCapiListClusters(t *testing.T) {
 	for _, provider := range providers {
 		t.Run(fmt.Sprintf("lists %s clusters from same namespace", provider), func(t *testing.T) {
 			t.Parallel()
-			namespace := "test-clusters"
+			namespace := testNamespace
 			harness.New(t).
 				CreateNamespace(namespace).
 				Cluster(namespace, provider+"-cluster-1").WithProvider(provider).Create().
@@ -220,7 +220,7 @@ func TestCapiListClusters(t *testing.T) {
 
 		t.Run(fmt.Sprintf("lists %s clusters with different phases", provider), func(t *testing.T) {
 			t.Parallel()
-			namespace := "test-clusters"
+			namespace := testNamespace
 			harness.New(t).
 				CreateNamespace(namespace).
 				Cluster(namespace, provider+"-pending").WithProvider(provider).WithPhase("Pending").Create().
@@ -236,7 +236,7 @@ func TestCapiListClusters(t *testing.T) {
 
 		t.Run(fmt.Sprintf("lists %s clusters with different versions", provider), func(t *testing.T) {
 			t.Parallel()
-			namespace := "test-clusters"
+			namespace := testNamespace
 			harness.New(t).
 				CreateNamespace(namespace).
 				Cluster(namespace, provider+"-v128").WithProvider(provider).WithVersion("v1.28.0").Create().
@@ -249,7 +249,7 @@ func TestCapiListClusters(t *testing.T) {
 
 		t.Run(fmt.Sprintf("lists %s clusters with partial machine readiness", provider), func(t *testing.T) {
 			t.Parallel()
-			namespace := "test-clusters"
+			namespace := testNamespace
 			harness.New(t).
 				CreateNamespace(namespace).
 				Cluster(namespace, provider+"-partial").WithProvider(provider).WithMachines(2, 1).Create().
@@ -261,7 +261,7 @@ func TestCapiListClusters(t *testing.T) {
 
 		t.Run(fmt.Sprintf("lists %s clusters with all machines ready", provider), func(t *testing.T) {
 			t.Parallel()
-			namespace := "test-clusters"
+			namespace := testNamespace
 			harness.New(t).
 				CreateNamespace(namespace).
 				Cluster(namespace, provider+"-all-ready").WithProvider(provider).WithMachines(3, 3).Create().
@@ -273,7 +273,7 @@ func TestCapiListClusters(t *testing.T) {
 
 		t.Run(fmt.Sprintf("lists %s clusters with no machines ready", provider), func(t *testing.T) {
 			t.Parallel()
-			namespace := "test-clusters"
+			namespace := testNamespace
 			harness.New(t).
 				CreateNamespace(namespace).
 				Cluster(namespace, provider+"-none-ready").WithProvider(provider).WithMachines(5, 0).Create().
@@ -285,7 +285,7 @@ func TestCapiListClusters(t *testing.T) {
 
 		t.Run(fmt.Sprintf("lists %s clusters with version from control plane", provider), func(t *testing.T) {
 			t.Parallel()
-			namespace := "test-clusters"
+			namespace := testNamespace
 			harness.New(t).
 				CreateNamespace(namespace).
 				Cluster(namespace, provider+"-cluster-1").
@@ -304,7 +304,7 @@ func TestCapiListClusters(t *testing.T) {
 
 		t.Run(fmt.Sprintf("lists %s cluster with version precedence over control plane", provider), func(t *testing.T) {
 			t.Parallel()
-			namespace := "test-clusters"
+			namespace := testNamespace
 			harness.New(t).
 				CreateNamespace(namespace).
 				Cluster(namespace, provider+"-cluster").
@@ -320,7 +320,7 @@ func TestCapiListClusters(t *testing.T) {
 
 		t.Run(fmt.Sprintf("lists %s clusters with different conditions", provider), func(t *testing.T) {
 			t.Parallel()
-			namespace := "test-clusters"
+			namespace := testNamespace
 			harness.New(t).
 				CreateNamespace(namespace).
 				// Cluster 1: All conditions True (healthy cluster)
@@ -349,7 +349,7 @@ func TestCapiListClusters(t *testing.T) {
 
 		t.Run(fmt.Sprintf("lists %s clusters with all properties", provider), func(t *testing.T) {
 			t.Parallel()
-			namespace := "test-clusters"
+			namespace := testNamespace
 			harness.New(t).
 				CreateNamespace(namespace).
 				Cluster(namespace, provider+"-cluster-1").WithProvider(provider).WithPhase("Provisioned").WithVersion("v1.28.0").WithMachines(3, 3).

--- a/test/integration/capi_list_machinedeployments_test.go
+++ b/test/integration/capi_list_machinedeployments_test.go
@@ -11,7 +11,7 @@ func TestCapiListMachineDeployments(t *testing.T) {
 
 	t.Run("lists machine deployments in namespace", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -28,7 +28,7 @@ func TestCapiListMachineDeployments(t *testing.T) {
 
 	t.Run("filters machine deployments by cluster name", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -44,7 +44,7 @@ func TestCapiListMachineDeployments(t *testing.T) {
 
 	t.Run("handles empty namespace", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -56,7 +56,7 @@ func TestCapiListMachineDeployments(t *testing.T) {
 
 	t.Run("returns error without namespace argument", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -67,7 +67,7 @@ func TestCapiListMachineDeployments(t *testing.T) {
 
 	t.Run("lists single machine deployment", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -82,7 +82,7 @@ func TestCapiListMachineDeployments(t *testing.T) {
 
 	t.Run("lists machine deployments with phase", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -99,7 +99,7 @@ func TestCapiListMachineDeployments(t *testing.T) {
 
 	t.Run("lists machine deployments with version", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -116,7 +116,7 @@ func TestCapiListMachineDeployments(t *testing.T) {
 
 	t.Run("lists machine deployments across clusters", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -133,7 +133,7 @@ func TestCapiListMachineDeployments(t *testing.T) {
 
 	t.Run("lists machine deployment with zero status replicas", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -148,7 +148,7 @@ func TestCapiListMachineDeployments(t *testing.T) {
 
 	t.Run("lists machine deployment without version", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -163,7 +163,7 @@ func TestCapiListMachineDeployments(t *testing.T) {
 
 	t.Run("lists machine deployment with mismatched replica counts", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -178,7 +178,7 @@ func TestCapiListMachineDeployments(t *testing.T) {
 
 	t.Run("lists machine deployment with nil replicas", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -193,7 +193,7 @@ func TestCapiListMachineDeployments(t *testing.T) {
 
 	t.Run("should return empty for non-existent cluster filter", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -209,7 +209,7 @@ func TestCapiListMachineDeployments(t *testing.T) {
 
 	t.Run("should handle zero replicas status", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -224,7 +224,7 @@ func TestCapiListMachineDeployments(t *testing.T) {
 
 	t.Run("should show deployment without phase", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).

--- a/test/integration/capi_list_machines_test.go
+++ b/test/integration/capi_list_machines_test.go
@@ -11,7 +11,7 @@ func TestCapiListMachines(t *testing.T) {
 
 	t.Run("lists machines in namespace", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -24,7 +24,7 @@ func TestCapiListMachines(t *testing.T) {
 
 	t.Run("filters machines by cluster name", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -39,7 +39,7 @@ func TestCapiListMachines(t *testing.T) {
 
 	t.Run("returns empty list when no machines exist", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -51,7 +51,7 @@ func TestCapiListMachines(t *testing.T) {
 
 	t.Run("lists machines with all ready", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -64,7 +64,7 @@ func TestCapiListMachines(t *testing.T) {
 
 	t.Run("lists machines with none ready", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -77,7 +77,7 @@ func TestCapiListMachines(t *testing.T) {
 
 	t.Run("returns error when namespace argument is missing", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -88,7 +88,7 @@ func TestCapiListMachines(t *testing.T) {
 
 	t.Run("lists machines from multiple clusters in same namespace", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -102,7 +102,7 @@ func TestCapiListMachines(t *testing.T) {
 
 	t.Run("returns empty list when filtering by non-existent cluster", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -116,7 +116,7 @@ func TestCapiListMachines(t *testing.T) {
 
 	t.Run("lists single machine", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -129,7 +129,7 @@ func TestCapiListMachines(t *testing.T) {
 
 	t.Run("should show machine with provider ID", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -145,7 +145,7 @@ func TestCapiListMachines(t *testing.T) {
 
 	t.Run("should show machine with empty phase", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -159,7 +159,7 @@ func TestCapiListMachines(t *testing.T) {
 
 	t.Run("should show machine with node ref", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).

--- a/test/integration/capi_list_machinesets_test.go
+++ b/test/integration/capi_list_machinesets_test.go
@@ -11,7 +11,7 @@ func TestCapiListMachineSets(t *testing.T) {
 
 	t.Run("lists machine sets in namespace", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -28,7 +28,7 @@ func TestCapiListMachineSets(t *testing.T) {
 
 	t.Run("filters machine sets by cluster name", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -46,7 +46,7 @@ func TestCapiListMachineSets(t *testing.T) {
 
 	t.Run("handles empty namespace", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -58,7 +58,7 @@ func TestCapiListMachineSets(t *testing.T) {
 
 	t.Run("returns error without namespace argument", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -69,7 +69,7 @@ func TestCapiListMachineSets(t *testing.T) {
 
 	t.Run("lists machine set with owner reference", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -85,7 +85,7 @@ func TestCapiListMachineSets(t *testing.T) {
 
 	t.Run("lists machine set with infrastructure reference", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -101,7 +101,7 @@ func TestCapiListMachineSets(t *testing.T) {
 
 	t.Run("lists single machine set", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -116,7 +116,7 @@ func TestCapiListMachineSets(t *testing.T) {
 
 	t.Run("lists machine sets across clusters", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -133,7 +133,7 @@ func TestCapiListMachineSets(t *testing.T) {
 
 	t.Run("lists machine set with nil replicas", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -148,7 +148,7 @@ func TestCapiListMachineSets(t *testing.T) {
 
 	t.Run("lists machine set with non-machinedeployment owner", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -164,7 +164,7 @@ func TestCapiListMachineSets(t *testing.T) {
 
 	t.Run("lists orphaned machine set without owner references", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -179,7 +179,7 @@ func TestCapiListMachineSets(t *testing.T) {
 
 	t.Run("should return empty for non-existent cluster filter", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).

--- a/test/integration/capi_node_status_test.go
+++ b/test/integration/capi_node_status_test.go
@@ -33,7 +33,7 @@ func TestCapiNodeStatus(t *testing.T) {
 
 		harness.New(t).
 			ToolCall("capi_node_status").
-			WithArg("namespace", "test-clusters").
+			WithArg("namespace", testNamespace).
 			AssertError("missing_machine_name.golden").
 			Execute()
 	})
@@ -128,7 +128,7 @@ func TestCapiNodeStatus(t *testing.T) {
 
 	t.Run("retrieves node status via machine_name lookup", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -183,7 +183,7 @@ func TestCapiNodeStatus(t *testing.T) {
 
 	t.Run("returns error when machine has no associated node", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -197,7 +197,7 @@ func TestCapiNodeStatus(t *testing.T) {
 
 	t.Run("returns error when machine_name not found", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).

--- a/test/integration/capi_vsphere_get_cluster_test.go
+++ b/test/integration/capi_vsphere_get_cluster_test.go
@@ -11,7 +11,7 @@ func TestCapiVSphereGetCluster(t *testing.T) {
 
 	t.Run("should get vSphere cluster details", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -25,7 +25,7 @@ func TestCapiVSphereGetCluster(t *testing.T) {
 
 	t.Run("should error for non-vSphere cluster", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -39,7 +39,7 @@ func TestCapiVSphereGetCluster(t *testing.T) {
 
 	t.Run("should error when cluster not found", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -62,7 +62,7 @@ func TestCapiVSphereGetCluster(t *testing.T) {
 
 	t.Run("should error when name is missing", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -74,7 +74,7 @@ func TestCapiVSphereGetCluster(t *testing.T) {
 
 	t.Run("should error for cluster with nil infrastructure ref", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).

--- a/test/integration/capi_vsphere_list_clusters_test.go
+++ b/test/integration/capi_vsphere_list_clusters_test.go
@@ -11,7 +11,7 @@ func TestCapiVSphereListClusters(t *testing.T) {
 
 	t.Run("should list vSphere clusters", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -24,7 +24,7 @@ func TestCapiVSphereListClusters(t *testing.T) {
 
 	t.Run("should show no vSphere clusters", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).
@@ -36,7 +36,7 @@ func TestCapiVSphereListClusters(t *testing.T) {
 
 	t.Run("should filter out non-vSphere clusters", func(t *testing.T) {
 		t.Parallel()
-		namespace := "test-clusters"
+		namespace := testNamespace
 
 		harness.New(t).
 			CreateNamespace(namespace).

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -8,6 +8,9 @@ import (
 	"github.com/giantswarm/mcp-capi/test/harness"
 )
 
+// testNamespace is the default namespace used across integration tests.
+const testNamespace = "test-clusters"
+
 func TestMain(m *testing.M) {
 	if err := harness.InitManager(); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to initialize test harness: %v\n", err)


### PR DESCRIPTION
## Summary

- PR #15 (devctl alignment) updates `Makefile.gen.go.mk` to run `golangci-lint run -E gosec -E goconst --timeout=15m ./...`, which surfaces a pile of pre-existing content issues in the repo. This PR fixes them so that the alignment change can merge cleanly.
- Mechanical fixes across 36 files: 498 insertions / 514 deletions. No behavior changes — all rewrites are semantically equivalent.
- Follow-up to PR #90 (same `fix pre-commit content violations` unblocking effort for architectbot's Align-files PR #15).

## Changes by linter

- **staticcheck QF1012**: `WriteString(fmt.Sprintf(...))` → `fmt.Fprintf(&sb, ...)`
- **staticcheck S1039**: drop pointless `fmt.Sprintf` wrappers around plain strings
- **staticcheck S1000**: simplify single-case `select` in `pkg/mcp/transport.go`
- **unused**: remove `filterClustersByProvider` (and its `clusterv1` import) in `pkg/mcp/handlers/provider_vsphere.go`
- **goconst**: extract `"infrastructure.cluster.x-k8s.io/v1beta1"`, `"KubeadmControlPlane"`, and the integration-test namespace `"test-clusters"` (223 call sites) to package-level constants; replace `"Ready"`/`"True"` with `clusterv1.ReadyCondition` / `corev1.ConditionTrue`
- **gosec G115**: bound `int → int32` replica conversions against `math.MaxInt32` with `#nosec` justification
- **gosec G304**: annotate test-fixture `os.ReadFile` paths in `test/harness/golden*.go` with `#nosec` justification
- **errcheck**: ignore return value of `fmt.Fprintf` in `cmd/version.go`

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/... ./cmd/... ./test/harness/...`
- [x] `golangci-lint run -E gosec -E goconst --timeout=15m ./...` (0 issues)
- [ ] CI green
- [ ] PR #15 re-runs lint and merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)