### PR TITLE
retrofit list tools to {items, nextCursor} JSON shape

### DIFF
--- a/pkg/capi/list.go
+++ b/pkg/capi/list.go
@@ -1,0 +1,245 @@
+package capi
+
+import (
+	"context"
+	"fmt"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1" //nolint:staticcheck // CAPI v1beta1 required until v1beta2 migration
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// PageOptions controls server-side pagination of CAPI list calls. Both
+// fields are forwarded to controller-runtime as client.Limit / client.Continue.
+type PageOptions struct {
+	// Cursor is the continue token returned from a previous page (empty
+	// for the first page).
+	Cursor string
+	// Limit is the maximum number of items the API server may return for
+	// this page. Zero leaves the API server's default in place.
+	Limit int64
+}
+
+// ClusterListItem is the per-cluster digest returned by paginated list
+// tools. Smaller than a full Cluster object — fits many entries under
+// the toolkit's response cap. The full object is available via
+// capi_get_cluster.
+type ClusterListItem struct {
+	Name               string            `json:"name"`
+	Namespace          string            `json:"namespace"`
+	Phase              string            `json:"phase,omitempty"`
+	Ready              bool              `json:"ready"`
+	ControlPlaneReady  bool              `json:"controlPlaneReady"`
+	InfraReady         bool              `json:"infraReady"`
+	Paused             bool              `json:"paused,omitempty"`
+	Version            string            `json:"version,omitempty"`
+	Provider           string            `json:"provider,omitempty"`
+	InfrastructureKind string            `json:"infrastructureKind,omitempty"`
+	TotalMachines      int               `json:"totalMachines"`
+	ReadyMachines      int               `json:"readyMachines"`
+	Labels             map[string]string `json:"labels,omitempty"`
+}
+
+// MachineListItem is the per-machine digest.
+type MachineListItem struct {
+	Name        string `json:"name"`
+	Namespace   string `json:"namespace"`
+	ClusterName string `json:"clusterName,omitempty"`
+	Phase       string `json:"phase,omitempty"`
+	NodeName    string `json:"nodeName,omitempty"`
+	ProviderID  string `json:"providerID,omitempty"`
+	Version     string `json:"version,omitempty"`
+	Ready       bool   `json:"ready"`
+}
+
+// MachineDeploymentListItem is the per-MD digest.
+type MachineDeploymentListItem struct {
+	Name              string `json:"name"`
+	Namespace         string `json:"namespace"`
+	ClusterName       string `json:"clusterName,omitempty"`
+	Phase             string `json:"phase,omitempty"`
+	Replicas          int32  `json:"replicas"`
+	ReadyReplicas     int32  `json:"readyReplicas"`
+	UpdatedReplicas   int32  `json:"updatedReplicas"`
+	AvailableReplicas int32  `json:"availableReplicas"`
+	Version           string `json:"version,omitempty"`
+}
+
+// MachineSetListItem is the per-MS digest.
+type MachineSetListItem struct {
+	Name              string `json:"name"`
+	Namespace         string `json:"namespace"`
+	ClusterName       string `json:"clusterName,omitempty"`
+	Replicas          int32  `json:"replicas"`
+	ReadyReplicas     int32  `json:"readyReplicas"`
+	AvailableReplicas int32  `json:"availableReplicas"`
+	OwnerKind         string `json:"ownerKind,omitempty"`
+	OwnerName         string `json:"ownerName,omitempty"`
+	InfraKind         string `json:"infrastructureKind,omitempty"`
+	InfraName         string `json:"infrastructureName,omitempty"`
+}
+
+// ListClustersPage fetches one page of clusters. Returned cursor is the
+// continue token to pass to the next call (empty when no more pages).
+func (c *Client) ListClustersPage(ctx context.Context, namespace string, labelSelector map[string]string, page PageOptions) (*clusterv1.ClusterList, string, error) {
+	out := &clusterv1.ClusterList{}
+	opts := buildListOpts(namespace, page)
+	if len(labelSelector) > 0 {
+		opts = append(opts, client.MatchingLabels(labelSelector))
+	}
+	if err := c.ctrlClient.List(ctx, out, opts...); err != nil {
+		return nil, "", fmt.Errorf("failed to list clusters: %w", err)
+	}
+	return out, out.GetContinue(), nil
+}
+
+// ListMachinesPage fetches one page of machines.
+func (c *Client) ListMachinesPage(ctx context.Context, namespace, clusterName string, page PageOptions) (*clusterv1.MachineList, string, error) {
+	out := &clusterv1.MachineList{}
+	opts := buildListOpts(namespace, page)
+	if clusterName != "" {
+		opts = append(opts, client.MatchingLabels{clusterv1.ClusterNameLabel: clusterName})
+	}
+	if err := c.ctrlClient.List(ctx, out, opts...); err != nil {
+		return nil, "", fmt.Errorf("failed to list machines: %w", err)
+	}
+	return out, out.GetContinue(), nil
+}
+
+// ListMachineDeploymentsPage fetches one page of machine deployments.
+func (c *Client) ListMachineDeploymentsPage(ctx context.Context, namespace, clusterName string, page PageOptions) (*clusterv1.MachineDeploymentList, string, error) {
+	out := &clusterv1.MachineDeploymentList{}
+	opts := buildListOpts(namespace, page)
+	if clusterName != "" {
+		opts = append(opts, client.MatchingLabels{clusterv1.ClusterNameLabel: clusterName})
+	}
+	if err := c.ctrlClient.List(ctx, out, opts...); err != nil {
+		return nil, "", fmt.Errorf("failed to list machine deployments: %w", err)
+	}
+	return out, out.GetContinue(), nil
+}
+
+// ListMachineSetsPage fetches one page of machine sets.
+func (c *Client) ListMachineSetsPage(ctx context.Context, namespace, clusterName string, page PageOptions) (*clusterv1.MachineSetList, string, error) {
+	out := &clusterv1.MachineSetList{}
+	opts := buildListOpts(namespace, page)
+	if clusterName != "" {
+		opts = append(opts, client.MatchingLabels{clusterv1.ClusterNameLabel: clusterName})
+	}
+	if err := c.ctrlClient.List(ctx, out, opts...); err != nil {
+		return nil, "", fmt.Errorf("failed to list machine sets: %w", err)
+	}
+	return out, out.GetContinue(), nil
+}
+
+func buildListOpts(namespace string, page PageOptions) []client.ListOption {
+	opts := []client.ListOption{}
+	if namespace != "" {
+		opts = append(opts, client.InNamespace(namespace))
+	}
+	if page.Limit > 0 {
+		opts = append(opts, client.Limit(page.Limit))
+	}
+	if page.Cursor != "" {
+		opts = append(opts, client.Continue(page.Cursor))
+	}
+	return opts
+}
+
+// SummarizeCluster builds a ClusterListItem from a Cluster + its machines.
+// machines may be nil; counts default to zero.
+func SummarizeCluster(cluster *clusterv1.Cluster, machines []clusterv1.Machine, provider Provider, version string) ClusterListItem {
+	item := ClusterListItem{
+		Name:              cluster.Name,
+		Namespace:         cluster.Namespace,
+		Phase:             string(cluster.Status.Phase),
+		Ready:             isConditionTrue(cluster.Status.Conditions, clusterv1.ReadyCondition),
+		ControlPlaneReady: cluster.Status.ControlPlaneReady,
+		InfraReady:        cluster.Status.InfrastructureReady,
+		Paused:            cluster.Spec.Paused,
+		Version:           version,
+		Provider:          string(provider),
+		Labels:            filterUserLabels(cluster.Labels),
+	}
+	if cluster.Spec.InfrastructureRef != nil {
+		item.InfrastructureKind = cluster.Spec.InfrastructureRef.Kind
+	}
+	for _, m := range machines {
+		item.TotalMachines++
+		if m.Status.NodeRef != nil {
+			item.ReadyMachines++
+		}
+	}
+	return item
+}
+
+// SummarizeMachine builds a MachineListItem from a Machine.
+func SummarizeMachine(m *clusterv1.Machine) MachineListItem {
+	item := MachineListItem{
+		Name:        m.Name,
+		Namespace:   m.Namespace,
+		ClusterName: m.Spec.ClusterName,
+		Phase:       m.Status.Phase,
+	}
+	if m.Status.NodeRef != nil {
+		item.NodeName = m.Status.NodeRef.Name
+	}
+	if m.Spec.ProviderID != nil {
+		item.ProviderID = *m.Spec.ProviderID
+	}
+	if m.Spec.Version != nil {
+		item.Version = *m.Spec.Version
+	}
+	for _, cond := range m.Status.Conditions {
+		if cond.Type == clusterv1.ReadyCondition && cond.Status == "True" {
+			item.Ready = true
+			break
+		}
+	}
+	return item
+}
+
+// SummarizeMachineDeployment builds a MachineDeploymentListItem.
+func SummarizeMachineDeployment(md *clusterv1.MachineDeployment) MachineDeploymentListItem {
+	item := MachineDeploymentListItem{
+		Name:              md.Name,
+		Namespace:         md.Namespace,
+		ClusterName:       md.Spec.ClusterName,
+		Phase:             md.Status.Phase,
+		ReadyReplicas:     md.Status.ReadyReplicas,
+		UpdatedReplicas:   md.Status.UpdatedReplicas,
+		AvailableReplicas: md.Status.AvailableReplicas,
+	}
+	if md.Spec.Replicas != nil {
+		item.Replicas = *md.Spec.Replicas
+	}
+	if md.Spec.Template.Spec.Version != nil {
+		item.Version = *md.Spec.Template.Spec.Version
+	}
+	return item
+}
+
+// SummarizeMachineSet builds a MachineSetListItem.
+func SummarizeMachineSet(ms *clusterv1.MachineSet) MachineSetListItem {
+	item := MachineSetListItem{
+		Name:              ms.Name,
+		Namespace:         ms.Namespace,
+		ClusterName:       ms.Spec.ClusterName,
+		ReadyReplicas:     ms.Status.ReadyReplicas,
+		AvailableReplicas: ms.Status.AvailableReplicas,
+	}
+	if ms.Spec.Replicas != nil {
+		item.Replicas = *ms.Spec.Replicas
+	}
+	for _, owner := range ms.OwnerReferences {
+		if owner.Kind == "MachineDeployment" {
+			item.OwnerKind = owner.Kind
+			item.OwnerName = owner.Name
+			break
+		}
+	}
+	if ms.Spec.Template.Spec.InfrastructureRef.Name != "" {
+		item.InfraKind = ms.Spec.Template.Spec.InfrastructureRef.Kind
+		item.InfraName = ms.Spec.Template.Spec.InfrastructureRef.Name
+	}
+	return item
+}

--- a/pkg/mcp/handlers/cluster.go
+++ b/pkg/mcp/handlers/cluster.go
@@ -121,8 +121,9 @@ func CreateListClustersHandler(serverCtx *ServerContext) server.ToolHandlerFunc 
 		arguments := request.GetArguments()
 		namespace, _ := arguments["namespace"].(string)
 		search, _ := arguments["search"].(string)
+		cursor, _ := arguments["cursor"].(string)
+		limitArg, _ := arguments["limit"].(float64)
 
-		// Parse label_selector from arguments
 		var labelSelector map[string]string
 		if ls, ok := arguments["label_selector"].(map[string]interface{}); ok && len(ls) > 0 {
 			labelSelector = make(map[string]string)
@@ -133,70 +134,89 @@ func CreateListClustersHandler(serverCtx *ServerContext) server.ToolHandlerFunc 
 			}
 		}
 
-		clusters, err := serverCtx.CAPIClient.ListClusters(ctx, namespace, labelSelector)
-		if err != nil {
-			return nil, fmt.Errorf("failed to list clusters: %w", err)
-		}
-
-		// If a search term is provided, filter clusters by name or label values
+		// search is a client-side substring match against name + label values.
+		// The K8s API server can't express that, so search-mode loads every
+		// matching cluster in one shot and ignores the cursor — the result
+		// fits on one page.
+		var clusters []clusterv1.Cluster
+		var nextCursor string
 		if search != "" {
+			all, err := serverCtx.CAPIClient.ListClusters(ctx, namespace, labelSelector)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list clusters: %w", err)
+			}
 			searchLower := strings.ToLower(search)
-			var filtered []clusterv1.Cluster
-			for _, cluster := range clusters.Items {
-				if strings.Contains(strings.ToLower(cluster.Name), searchLower) {
-					filtered = append(filtered, cluster)
-					continue
-				}
-				matched := false
-				for _, v := range cluster.Labels {
-					if strings.Contains(strings.ToLower(v), searchLower) {
-						matched = true
-						break
-					}
-				}
-				if matched {
-					filtered = append(filtered, cluster)
+			for _, cl := range all.Items {
+				if matchesSearch(cl.Name, cl.Labels, searchLower) {
+					clusters = append(clusters, cl)
 				}
 			}
-			clusters.Items = filtered
+		} else {
+			page, next, err := serverCtx.CAPIClient.ListClustersPage(ctx, namespace, labelSelector, capi.PageOptions{
+				Cursor: cursor,
+				Limit:  pageLimit(limitArg, 50, 200),
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to list clusters: %w", err)
+			}
+			clusters = page.Items
+			nextCursor = next
 		}
 
-		// Bulk fetch all machines in the namespace to avoid N+1 queries
+		// Bulk-fetch machines in the namespace for an O(1) join. With
+		// namespace="" this fetches all machines in the management cluster;
+		// the cost is unchanged from the pre-pagination behaviour.
 		allMachines, err := serverCtx.CAPIClient.ListMachines(ctx, namespace, "")
 		if err != nil {
 			return nil, fmt.Errorf("failed to list machines: %w", err)
 		}
-
-		// Group machines by cluster name
 		machinesByCluster := make(map[string][]clusterv1.Machine)
 		for _, m := range allMachines.Items {
-			clusterName := m.Labels[clusterv1.ClusterNameLabel]
-			key := m.Namespace + "/" + clusterName
+			key := m.Namespace + "/" + m.Labels[clusterv1.ClusterNameLabel]
 			machinesByCluster[key] = append(machinesByCluster[key], m)
 		}
 
-		var content strings.Builder
-		fmt.Fprintf(&content, "Found %d clusters:\n\n", len(clusters.Items))
-
-		for i := range clusters.Items {
-			cluster := &clusters.Items[i]
-			key := cluster.Namespace + "/" + cluster.Name
-			status, _ := serverCtx.CAPIClient.GetClusterStatusFromList(ctx, cluster, machinesByCluster[key])
-			if status != nil {
-				content.WriteString(capi.FormatClusterInfo(status))
-				content.WriteString("\n---\n\n")
-			}
+		items := make([]capi.ClusterListItem, 0, len(clusters))
+		for i := range clusters {
+			cluster := &clusters[i]
+			provider, _ := serverCtx.CAPIClient.GetProviderForCluster(ctx, cluster.Namespace, cluster.Name)
+			version := clusterVersion(serverCtx, ctx, cluster)
+			items = append(items, capi.SummarizeCluster(
+				cluster,
+				machinesByCluster[cluster.Namespace+"/"+cluster.Name],
+				provider, version,
+			))
 		}
-
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: textContentType,
-					Text: content.String(),
-				},
-			},
-		}, nil
+		return paginatedResult(items, nextCursor)
 	}
+}
+
+// matchesSearch reports whether name or any label value contains
+// searchLower (already lower-cased).
+func matchesSearch(name string, labels map[string]string, searchLower string) bool {
+	if strings.Contains(strings.ToLower(name), searchLower) {
+		return true
+	}
+	for _, v := range labels {
+		if strings.Contains(strings.ToLower(v), searchLower) {
+			return true
+		}
+	}
+	return false
+}
+
+// clusterVersion resolves the effective Kubernetes version for a cluster:
+// Spec.Topology.Version when set, falling back to KubeadmControlPlane spec.
+func clusterVersion(serverCtx *ServerContext, ctx context.Context, cluster *clusterv1.Cluster) string {
+	if cluster.Spec.Topology != nil && cluster.Spec.Topology.Version != "" {
+		return cluster.Spec.Topology.Version
+	}
+	if cluster.Spec.ControlPlaneRef != nil && cluster.Spec.ControlPlaneRef.Kind == "KubeadmControlPlane" {
+		if kcp, err := serverCtx.CAPIClient.GetKubeadmControlPlane(ctx, cluster.Namespace, cluster.Spec.ControlPlaneRef.Name); err == nil {
+			return kcp.Spec.Version
+		}
+	}
+	return ""
 }
 
 // createGetClusterHandler creates a handler for getting a specific cluster

--- a/pkg/mcp/handlers/jsonresult.go
+++ b/pkg/mcp/handlers/jsonresult.go
@@ -1,0 +1,51 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// paginatedResult renders a `{ items, nextCursor }` JSON payload as the
+// canonical MCP-toolkit paginated tool result. nextCursor is omitted when
+// empty (no more pages). items must marshal to a JSON array — typically a
+// slice of digest structs from package capi.
+func paginatedResult(items any, nextCursor string) (*mcp.CallToolResult, error) {
+	payload := struct {
+		Items      any        `json:"items"`
+		NextCursor mcp.Cursor `json:"nextCursor,omitempty"`
+	}{
+		Items:      items,
+		NextCursor: mcp.Cursor(nextCursor),
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal paginated result: %w", err)
+	}
+	return mcp.NewToolResultText(string(body)), nil
+}
+
+// jsonResult renders any value as a JSON tool result. Used for non-paginated
+// list tools (bounded enums) and for tools whose response is a single object.
+func jsonResult(v any) (*mcp.CallToolResult, error) {
+	body, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("marshal result: %w", err)
+	}
+	return mcp.NewToolResultText(string(body)), nil
+}
+
+// pageLimit clamps a caller-supplied limit into a sensible range.
+// Zero / negative → defaultLimit. Values above maxLimit → maxLimit. The
+// returned int64 is what controller-runtime's client.Limit expects.
+func pageLimit(raw float64, defaultLimit, maxLimit int64) int64 {
+	if raw <= 0 {
+		return defaultLimit
+	}
+	n := int64(raw)
+	if n > maxLimit {
+		return maxLimit
+	}
+	return n
+}

--- a/pkg/mcp/handlers/jsonresult_test.go
+++ b/pkg/mcp/handlers/jsonresult_test.go
@@ -1,0 +1,73 @@
+package handlers
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestPaginatedResult_OmitsEmptyCursor(t *testing.T) {
+	res, err := paginatedResult([]string{"a", "b"}, "")
+	if err != nil {
+		t.Fatalf("paginatedResult: %v", err)
+	}
+	body := textBody(t, res)
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(body), &got); err != nil {
+		t.Fatalf("payload not JSON: %v\n%s", err, body)
+	}
+	if _, hasCursor := got["nextCursor"]; hasCursor {
+		t.Errorf("nextCursor should be omitted when empty, got: %s", body)
+	}
+	if items, ok := got["items"].([]any); !ok || len(items) != 2 {
+		t.Errorf("items should be a 2-element array, got: %v", got["items"])
+	}
+}
+
+func TestPaginatedResult_IncludesCursor(t *testing.T) {
+	res, err := paginatedResult([]int{1, 2, 3}, "page-2-token")
+	if err != nil {
+		t.Fatalf("paginatedResult: %v", err)
+	}
+	body := textBody(t, res)
+	if !strings.Contains(body, `"nextCursor":"page-2-token"`) {
+		t.Errorf("nextCursor missing from payload: %s", body)
+	}
+}
+
+func TestPageLimit_ClampsAndDefaults(t *testing.T) {
+	cases := []struct {
+		name string
+		in   float64
+		want int64
+	}{
+		{"zero applies default", 0, 50},
+		{"negative applies default", -1, 50},
+		{"in-range passes through", 25, 25},
+		{"over max clamps to max", 9999, 200},
+		{"max boundary", 200, 200},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := pageLimit(c.in, 50, 200)
+			if got != c.want {
+				t.Errorf("pageLimit(%v) = %d, want %d", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func textBody(t *testing.T, res *mcp.CallToolResult) string {
+	t.Helper()
+	if len(res.Content) != 1 {
+		t.Fatalf("expected 1 content entry, got %d", len(res.Content))
+	}
+	tc, ok := res.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", res.Content[0])
+	}
+	return tc.Text
+}

--- a/pkg/mcp/handlers/machine.go
+++ b/pkg/mcp/handlers/machine.go
@@ -21,51 +21,22 @@ func CreateListMachinesHandler(serverCtx *ServerContext) server.ToolHandlerFunc 
 			return nil, fmt.Errorf("namespace argument is required")
 		}
 		clusterName, _ := arguments["clusterName"].(string)
+		cursor, _ := arguments["cursor"].(string)
+		limitArg, _ := arguments["limit"].(float64)
 
-		machines, err := serverCtx.CAPIClient.ListMachines(ctx, namespace, clusterName)
+		page, nextCursor, err := serverCtx.CAPIClient.ListMachinesPage(ctx, namespace, clusterName, capi.PageOptions{
+			Cursor: cursor,
+			Limit:  pageLimit(limitArg, 50, 200),
+		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to list machines: %w", err)
 		}
 
-		var content strings.Builder
-		fmt.Fprintf(&content, "Found %d machines", len(machines.Items))
-		if clusterName != "" {
-			fmt.Fprintf(&content, " in cluster %s", clusterName)
+		items := make([]capi.MachineListItem, 0, len(page.Items))
+		for i := range page.Items {
+			items = append(items, capi.SummarizeMachine(&page.Items[i]))
 		}
-		content.WriteString(":\n\n")
-
-		for _, machine := range machines.Items {
-			fmt.Fprintf(&content, "Machine: %s/%s\n", machine.Namespace, machine.Name)
-			fmt.Fprintf(&content, "  Cluster: %s\n", machine.Spec.ClusterName)
-			if machine.Status.Phase != "" {
-				fmt.Fprintf(&content, "  Phase: %s\n", machine.Status.Phase)
-			}
-			if machine.Status.NodeRef != nil {
-				fmt.Fprintf(&content, "  Node: %s\n", machine.Status.NodeRef.Name)
-			}
-			if machine.Spec.ProviderID != nil {
-				fmt.Fprintf(&content, "  Provider ID: %s\n", *machine.Spec.ProviderID)
-			}
-			// Check if machine has Ready condition
-			ready := false
-			for _, condition := range machine.Status.Conditions {
-				if condition.Type == "Ready" && condition.Status == "True" {
-					ready = true
-					break
-				}
-			}
-			fmt.Fprintf(&content, "  Ready: %v\n", ready)
-			content.WriteString("\n")
-		}
-
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: textContentType,
-					Text: content.String(),
-				},
-			},
-		}, nil
+		return paginatedResult(items, nextCursor)
 	}
 }
 
@@ -78,48 +49,22 @@ func CreateListMachineDeploymentsHandler(serverCtx *ServerContext) server.ToolHa
 			return nil, fmt.Errorf("namespace argument is required")
 		}
 		clusterName, _ := arguments["clusterName"].(string)
+		cursor, _ := arguments["cursor"].(string)
+		limitArg, _ := arguments["limit"].(float64)
 
-		mds, err := serverCtx.CAPIClient.ListMachineDeployments(ctx, namespace, clusterName)
+		page, nextCursor, err := serverCtx.CAPIClient.ListMachineDeploymentsPage(ctx, namespace, clusterName, capi.PageOptions{
+			Cursor: cursor,
+			Limit:  pageLimit(limitArg, 50, 200),
+		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to list machine deployments: %w", err)
 		}
 
-		var content strings.Builder
-		fmt.Fprintf(&content, "Found %d machine deployments", len(mds.Items))
-		if clusterName != "" {
-			fmt.Fprintf(&content, " in cluster %s", clusterName)
+		items := make([]capi.MachineDeploymentListItem, 0, len(page.Items))
+		for i := range page.Items {
+			items = append(items, capi.SummarizeMachineDeployment(&page.Items[i]))
 		}
-		content.WriteString(":\n\n")
-
-		for _, md := range mds.Items {
-			fmt.Fprintf(&content, "MachineDeployment: %s/%s\n", md.Namespace, md.Name)
-			fmt.Fprintf(&content, "  Cluster: %s\n", md.Spec.ClusterName)
-			if md.Spec.Replicas != nil {
-				fmt.Fprintf(&content, "  Replicas: %d\n", *md.Spec.Replicas)
-			}
-			if md.Status.Replicas > 0 {
-				fmt.Fprintf(&content, "  Status: %d ready / %d updated / %d available\n",
-					md.Status.ReadyReplicas,
-					md.Status.UpdatedReplicas,
-					md.Status.AvailableReplicas)
-			}
-			if md.Status.Phase != "" {
-				fmt.Fprintf(&content, "  Phase: %s\n", md.Status.Phase)
-			}
-			if md.Spec.Template.Spec.Version != nil {
-				fmt.Fprintf(&content, "  Kubernetes Version: %s\n", *md.Spec.Template.Spec.Version)
-			}
-			content.WriteString("\n")
-		}
-
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: textContentType,
-					Text: content.String(),
-				},
-			},
-		}, nil
+		return paginatedResult(items, nextCursor)
 	}
 }
 
@@ -655,52 +600,22 @@ func CreateListMachineSetsHandler(serverCtx *ServerContext) server.ToolHandlerFu
 			return nil, fmt.Errorf("namespace argument is required")
 		}
 		clusterName, _ := arguments["clusterName"].(string)
+		cursor, _ := arguments["cursor"].(string)
+		limitArg, _ := arguments["limit"].(float64)
 
-		machineSets, err := serverCtx.CAPIClient.ListMachineSets(ctx, namespace, clusterName)
+		page, nextCursor, err := serverCtx.CAPIClient.ListMachineSetsPage(ctx, namespace, clusterName, capi.PageOptions{
+			Cursor: cursor,
+			Limit:  pageLimit(limitArg, 50, 200),
+		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to list machine sets: %w", err)
 		}
 
-		var content strings.Builder
-		fmt.Fprintf(&content, "Found %d machine sets", len(machineSets.Items))
-		if clusterName != "" {
-			fmt.Fprintf(&content, " in cluster %s", clusterName)
+		items := make([]capi.MachineSetListItem, 0, len(page.Items))
+		for i := range page.Items {
+			items = append(items, capi.SummarizeMachineSet(&page.Items[i]))
 		}
-		content.WriteString(":\n\n")
-
-		for _, ms := range machineSets.Items {
-			fmt.Fprintf(&content, "MachineSet: %s/%s\n", ms.Namespace, ms.Name)
-			fmt.Fprintf(&content, "  Cluster: %s\n", ms.Spec.ClusterName)
-			if ms.Spec.Replicas != nil {
-				fmt.Fprintf(&content, "  Replicas: %d\n", *ms.Spec.Replicas)
-			}
-			fmt.Fprintf(&content, "  Ready: %d/%d\n", ms.Status.ReadyReplicas, ms.Status.Replicas)
-			fmt.Fprintf(&content, "  Available: %d\n", ms.Status.AvailableReplicas)
-
-			// Show owner reference (usually MachineDeployment)
-			for _, owner := range ms.OwnerReferences {
-				if owner.Kind == "MachineDeployment" {
-					fmt.Fprintf(&content, "  Owner: MachineDeployment/%s\n", owner.Name)
-				}
-			}
-
-			// Show machine template
-			if ms.Spec.Template.Spec.InfrastructureRef.Name != "" {
-				fmt.Fprintf(&content, "  Infrastructure: %s/%s\n",
-					ms.Spec.Template.Spec.InfrastructureRef.Kind,
-					ms.Spec.Template.Spec.InfrastructureRef.Name)
-			}
-			content.WriteString("\n")
-		}
-
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: textContentType,
-					Text: content.String(),
-				},
-			},
-		}, nil
+		return paginatedResult(items, nextCursor)
 	}
 }
 

--- a/pkg/mcp/handlers/provider_aws.go
+++ b/pkg/mcp/handlers/provider_aws.go
@@ -19,52 +19,24 @@ func CreateAWSListClustersHandler(serverCtx *ServerContext) server.ToolHandlerFu
 		arguments := request.GetArguments()
 		namespace, _ := arguments["namespace"].(string)
 
-		// List all clusters
 		clusters, err := serverCtx.CAPIClient.ListClusters(ctx, namespace, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to list clusters: %w", err)
 		}
 
-		var content strings.Builder
-		content.WriteString("AWS Clusters:\n\n")
-
-		awsClusterCount := 0
-		for _, cluster := range clusters.Items {
-			// Check if this is an AWS cluster
-			if cluster.Spec.InfrastructureRef != nil &&
-				(cluster.Spec.InfrastructureRef.Kind == "AWSCluster" ||
-					cluster.Spec.InfrastructureRef.Kind == "AWSManagedCluster") {
-				awsClusterCount++
-
-				fmt.Fprintf(&content, "Cluster: %s/%s\n", cluster.Namespace, cluster.Name)
-				fmt.Fprintf(&content, "  Infrastructure: %s\n", cluster.Spec.InfrastructureRef.Kind)
-				fmt.Fprintf(&content, "  Phase: %s\n", cluster.Status.Phase)
-				fmt.Fprintf(&content, "  Ready: %v\n", cluster.Status.InfrastructureReady)
-
-				// Try to get provider information
-				provider, _ := serverCtx.CAPIClient.GetProviderForCluster(ctx, cluster.Namespace, cluster.Name)
-				if provider == capi.ProviderAWS {
-					content.WriteString("  Provider: AWS (confirmed)\n")
-				}
-
-				content.WriteString("\n")
+		items := make([]capi.ClusterListItem, 0, len(clusters.Items))
+		for i := range clusters.Items {
+			cl := &clusters.Items[i]
+			if cl.Spec.InfrastructureRef == nil {
+				continue
 			}
+			if cl.Spec.InfrastructureRef.Kind != "AWSCluster" && cl.Spec.InfrastructureRef.Kind != "AWSManagedCluster" {
+				continue
+			}
+			provider, _ := serverCtx.CAPIClient.GetProviderForCluster(ctx, cl.Namespace, cl.Name)
+			items = append(items, capi.SummarizeCluster(cl, nil, provider, ""))
 		}
-
-		if awsClusterCount == 0 {
-			content.WriteString("No AWS clusters found.\n")
-		} else {
-			fmt.Fprintf(&content, "Total AWS clusters: %d\n", awsClusterCount)
-		}
-
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: textContentType,
-					Text: content.String(),
-				},
-			},
-		}, nil
+		return paginatedResult(items, "")
 	}
 }
 

--- a/pkg/mcp/handlers/provider_azure_gcp.go
+++ b/pkg/mcp/handlers/provider_azure_gcp.go
@@ -19,52 +19,24 @@ func CreateAzureListClustersHandler(serverCtx *ServerContext) server.ToolHandler
 		arguments := request.GetArguments()
 		namespace, _ := arguments["namespace"].(string)
 
-		// List all clusters
 		clusters, err := serverCtx.CAPIClient.ListClusters(ctx, namespace, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to list clusters: %w", err)
 		}
 
-		var content strings.Builder
-		content.WriteString("Azure Clusters:\n\n")
-
-		azureClusterCount := 0
-		for _, cluster := range clusters.Items {
-			// Check if this is an Azure cluster
-			if cluster.Spec.InfrastructureRef != nil &&
-				(cluster.Spec.InfrastructureRef.Kind == "AzureCluster" ||
-					cluster.Spec.InfrastructureRef.Kind == "AzureManagedCluster") {
-				azureClusterCount++
-
-				fmt.Fprintf(&content, "Cluster: %s/%s\n", cluster.Namespace, cluster.Name)
-				fmt.Fprintf(&content, "  Infrastructure: %s\n", cluster.Spec.InfrastructureRef.Kind)
-				fmt.Fprintf(&content, "  Phase: %s\n", cluster.Status.Phase)
-				fmt.Fprintf(&content, "  Ready: %v\n", cluster.Status.InfrastructureReady)
-
-				// Try to get provider information
-				provider, _ := serverCtx.CAPIClient.GetProviderForCluster(ctx, cluster.Namespace, cluster.Name)
-				if provider == capi.ProviderAzure {
-					content.WriteString("  Provider: Azure (confirmed)\n")
-				}
-
-				content.WriteString("\n")
+		items := make([]capi.ClusterListItem, 0, len(clusters.Items))
+		for i := range clusters.Items {
+			cl := &clusters.Items[i]
+			if cl.Spec.InfrastructureRef == nil {
+				continue
 			}
+			if cl.Spec.InfrastructureRef.Kind != "AzureCluster" && cl.Spec.InfrastructureRef.Kind != "AzureManagedCluster" {
+				continue
+			}
+			provider, _ := serverCtx.CAPIClient.GetProviderForCluster(ctx, cl.Namespace, cl.Name)
+			items = append(items, capi.SummarizeCluster(cl, nil, provider, ""))
 		}
-
-		if azureClusterCount == 0 {
-			content.WriteString("No Azure clusters found.\n")
-		} else {
-			fmt.Fprintf(&content, "Total Azure clusters: %d\n", azureClusterCount)
-		}
-
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: textContentType,
-					Text: content.String(),
-				},
-			},
-		}, nil
+		return paginatedResult(items, "")
 	}
 }
 
@@ -183,52 +155,24 @@ func CreateGCPListClustersHandler(serverCtx *ServerContext) server.ToolHandlerFu
 		arguments := request.GetArguments()
 		namespace, _ := arguments["namespace"].(string)
 
-		// List all clusters
 		clusters, err := serverCtx.CAPIClient.ListClusters(ctx, namespace, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to list clusters: %w", err)
 		}
 
-		var content strings.Builder
-		content.WriteString("GCP Clusters:\n\n")
-
-		gcpClusterCount := 0
-		for _, cluster := range clusters.Items {
-			// Check if this is a GCP cluster
-			if cluster.Spec.InfrastructureRef != nil &&
-				(cluster.Spec.InfrastructureRef.Kind == "GCPCluster" ||
-					cluster.Spec.InfrastructureRef.Kind == "GCPManagedCluster") {
-				gcpClusterCount++
-
-				fmt.Fprintf(&content, "Cluster: %s/%s\n", cluster.Namespace, cluster.Name)
-				fmt.Fprintf(&content, "  Infrastructure: %s\n", cluster.Spec.InfrastructureRef.Kind)
-				fmt.Fprintf(&content, "  Phase: %s\n", cluster.Status.Phase)
-				fmt.Fprintf(&content, "  Ready: %v\n", cluster.Status.InfrastructureReady)
-
-				// Try to get provider information
-				provider, _ := serverCtx.CAPIClient.GetProviderForCluster(ctx, cluster.Namespace, cluster.Name)
-				if provider == capi.ProviderGCP {
-					content.WriteString("  Provider: GCP (confirmed)\n")
-				}
-
-				content.WriteString("\n")
+		items := make([]capi.ClusterListItem, 0, len(clusters.Items))
+		for i := range clusters.Items {
+			cl := &clusters.Items[i]
+			if cl.Spec.InfrastructureRef == nil {
+				continue
 			}
+			if cl.Spec.InfrastructureRef.Kind != "GCPCluster" && cl.Spec.InfrastructureRef.Kind != "GCPManagedCluster" {
+				continue
+			}
+			provider, _ := serverCtx.CAPIClient.GetProviderForCluster(ctx, cl.Namespace, cl.Name)
+			items = append(items, capi.SummarizeCluster(cl, nil, provider, ""))
 		}
-
-		if gcpClusterCount == 0 {
-			content.WriteString("No GCP clusters found.\n")
-		} else {
-			fmt.Fprintf(&content, "Total GCP clusters: %d\n", gcpClusterCount)
-		}
-
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: textContentType,
-					Text: content.String(),
-				},
-			},
-		}, nil
+		return paginatedResult(items, "")
 	}
 }
 

--- a/pkg/mcp/handlers/provider_generic.go
+++ b/pkg/mcp/handlers/provider_generic.go
@@ -9,60 +9,28 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
+// providerInfo is the per-provider entry in the list_infrastructure_providers
+// tool result. This is a bounded enum (4 entries today), so the result is
+// returned as a single page with no nextCursor.
+type providerInfo struct {
+	Name        string `json:"name"`
+	APIVersion  string `json:"apiVersion"`
+	Description string `json:"description"`
+}
+
 // createListInfrastructureProvidersHandler creates a handler for listing available infrastructure providers
 func CreateListInfrastructureProvidersHandler(serverCtx *ServerContext) server.ToolHandlerFunc {
 	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		// In a real implementation, this would discover installed providers
-		// For now, we'll return a static list of commonly available providers
-
-		var content strings.Builder
-		content.WriteString("Available Infrastructure Providers:\n\n")
-
-		providers := []struct {
-			Name        string
-			APIVersion  string
-			Description string
-		}{
-			{
-				Name:        "AWS",
-				APIVersion:  "infrastructure.cluster.x-k8s.io/v1beta2",
-				Description: "Amazon Web Services infrastructure provider",
-			},
-			{
-				Name:        "Azure",
-				APIVersion:  infraAPIV1Beta1,
-				Description: "Microsoft Azure infrastructure provider",
-			},
-			{
-				Name:        "GCP",
-				APIVersion:  infraAPIV1Beta1,
-				Description: "Google Cloud Platform infrastructure provider",
-			},
-			{
-				Name:        "vSphere",
-				APIVersion:  infraAPIV1Beta1,
-				Description: "VMware vSphere infrastructure provider",
-			},
+		// Static list — does not reflect actually installed providers in
+		// the management cluster. To discover deployed providers,
+		// inspect the controller manager namespace.
+		providers := []providerInfo{
+			{Name: "AWS", APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2", Description: "Amazon Web Services infrastructure provider"},
+			{Name: "Azure", APIVersion: infraAPIV1Beta1, Description: "Microsoft Azure infrastructure provider"},
+			{Name: "GCP", APIVersion: infraAPIV1Beta1, Description: "Google Cloud Platform infrastructure provider"},
+			{Name: "vSphere", APIVersion: infraAPIV1Beta1, Description: "VMware vSphere infrastructure provider"},
 		}
-
-		for _, provider := range providers {
-			fmt.Fprintf(&content, "Provider: %s\n", provider.Name)
-			fmt.Fprintf(&content, "  API Version: %s\n", provider.APIVersion)
-			fmt.Fprintf(&content, "  Description: %s\n", provider.Description)
-			content.WriteString("\n")
-		}
-
-		content.WriteString("Note: This list shows commonly available providers.\n")
-		content.WriteString("To see actually installed providers in your cluster, check the deployed controllers.\n")
-
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: textContentType,
-					Text: content.String(),
-				},
-			},
-		}, nil
+		return paginatedResult(providers, "")
 	}
 }
 

--- a/pkg/mcp/handlers/provider_vsphere.go
+++ b/pkg/mcp/handlers/provider_vsphere.go
@@ -19,51 +19,21 @@ func CreateVSphereListClustersHandler(serverCtx *ServerContext) server.ToolHandl
 		arguments := request.GetArguments()
 		namespace, _ := arguments["namespace"].(string)
 
-		// List all clusters
 		clusters, err := serverCtx.CAPIClient.ListClusters(ctx, namespace, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to list clusters: %w", err)
 		}
 
-		var content strings.Builder
-		content.WriteString("vSphere Clusters:\n\n")
-
-		vsphereClusterCount := 0
-		for _, cluster := range clusters.Items {
-			// Check if this is a vSphere cluster
-			if cluster.Spec.InfrastructureRef != nil &&
-				cluster.Spec.InfrastructureRef.Kind == "VSphereCluster" {
-				vsphereClusterCount++
-
-				fmt.Fprintf(&content, "Cluster: %s/%s\n", cluster.Namespace, cluster.Name)
-				fmt.Fprintf(&content, "  Infrastructure: %s\n", cluster.Spec.InfrastructureRef.Kind)
-				fmt.Fprintf(&content, "  Phase: %s\n", cluster.Status.Phase)
-				fmt.Fprintf(&content, "  Ready: %v\n", cluster.Status.InfrastructureReady)
-
-				// Try to get provider information
-				provider, _ := serverCtx.CAPIClient.GetProviderForCluster(ctx, cluster.Namespace, cluster.Name)
-				if provider == capi.ProviderVSphere {
-					content.WriteString("  Provider: vSphere (confirmed)\n")
-				}
-
-				content.WriteString("\n")
+		items := make([]capi.ClusterListItem, 0, len(clusters.Items))
+		for i := range clusters.Items {
+			cl := &clusters.Items[i]
+			if cl.Spec.InfrastructureRef == nil || cl.Spec.InfrastructureRef.Kind != "VSphereCluster" {
+				continue
 			}
+			provider, _ := serverCtx.CAPIClient.GetProviderForCluster(ctx, cl.Namespace, cl.Name)
+			items = append(items, capi.SummarizeCluster(cl, nil, provider, ""))
 		}
-
-		if vsphereClusterCount == 0 {
-			content.WriteString("No vSphere clusters found.\n")
-		} else {
-			fmt.Fprintf(&content, "Total vSphere clusters: %d\n", vsphereClusterCount)
-		}
-
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: textContentType,
-					Text: content.String(),
-				},
-			},
-		}, nil
+		return paginatedResult(items, "")
 	}
 }
 

--- a/pkg/mcp/handlers/registry.go
+++ b/pkg/mcp/handlers/registry.go
@@ -66,10 +66,12 @@ func buildClusterTools(serverCtx *ServerContext) []ToolRegistration {
 	tools = append(tools, ToolRegistration{
 		Tool: mcp.NewTool(
 			"capi_list_clusters",
-			mcp.WithDescription("List all CAPI clusters. Supports filtering by namespace, label key=value pairs, or searching by a term that matches any label value."),
+			mcp.WithDescription("List CAPI clusters as paginated JSON of the shape {items, nextCursor}. Filter by namespace and/or label_selector. The optional search term matches any label value or the cluster name (case-insensitive); search-mode loads all matching clusters in one page and ignores cursor."),
 			mcp.WithString("namespace", mcp.Description("Namespace to filter clusters (optional, empty for all)")),
 			mcp.WithObject("label_selector", mcp.Description("Label key-value pairs to filter clusters (e.g. {\"env\": \"production\", \"team\": \"platform\"})")),
-			mcp.WithString("search", mcp.Description("Search term to match against cluster names and label values (case-insensitive)")),
+			mcp.WithString("search", mcp.Description("Search term to match against cluster names and label values (case-insensitive). When set, cursor is ignored.")),
+			mcp.WithString("cursor", mcp.Description("Continue token from a previous page's nextCursor. Empty for the first page.")),
+			mcp.WithNumber("limit", mcp.Description("Page size, default 50, max 200.")),
 		),
 		Handler: CreateListClustersHandler(serverCtx),
 	})
@@ -233,9 +235,11 @@ func buildMachineTools(serverCtx *ServerContext) []ToolRegistration {
 	tools = append(tools, ToolRegistration{
 		Tool: mcp.NewTool(
 			"capi_list_machines",
-			mcp.WithDescription("List CAPI machines"),
+			mcp.WithDescription("List CAPI machines as paginated JSON of the shape {items, nextCursor}."),
 			mcp.WithString("namespace", mcp.Required(), mcp.Description("Namespace to search")),
 			mcp.WithString("clusterName", mcp.Description("Filter by cluster name")),
+			mcp.WithString("cursor", mcp.Description("Continue token from a previous page's nextCursor. Empty for the first page.")),
+			mcp.WithNumber("limit", mcp.Description("Page size, default 50, max 200.")),
 		),
 		Handler: CreateListMachinesHandler(serverCtx),
 	})
@@ -278,9 +282,11 @@ func buildMachineTools(serverCtx *ServerContext) []ToolRegistration {
 	tools = append(tools, ToolRegistration{
 		Tool: mcp.NewTool(
 			"capi_list_machinedeployments",
-			mcp.WithDescription("List machine deployments"),
+			mcp.WithDescription("List machine deployments as paginated JSON of the shape {items, nextCursor}."),
 			mcp.WithString("namespace", mcp.Required(), mcp.Description("Namespace to search")),
 			mcp.WithString("clusterName", mcp.Description("Filter by cluster name")),
+			mcp.WithString("cursor", mcp.Description("Continue token from a previous page's nextCursor. Empty for the first page.")),
+			mcp.WithNumber("limit", mcp.Description("Page size, default 50, max 200.")),
 		),
 		Handler: CreateListMachineDeploymentsHandler(serverCtx),
 	})
@@ -345,9 +351,11 @@ func buildMachineTools(serverCtx *ServerContext) []ToolRegistration {
 	tools = append(tools, ToolRegistration{
 		Tool: mcp.NewTool(
 			"capi_list_machinesets",
-			mcp.WithDescription("List machine sets"),
+			mcp.WithDescription("List machine sets as paginated JSON of the shape {items, nextCursor}."),
 			mcp.WithString("namespace", mcp.Required(), mcp.Description("Namespace")),
 			mcp.WithString("clusterName", mcp.Description("Filter by cluster name")),
+			mcp.WithString("cursor", mcp.Description("Continue token from a previous page's nextCursor. Empty for the first page.")),
+			mcp.WithNumber("limit", mcp.Description("Page size, default 50, max 200.")),
 		),
 		Handler: CreateListMachineSetsHandler(serverCtx),
 	})


### PR DESCRIPTION
## Summary

Stacked on top of #113 (toolkit adoption). Adopts the [`mcp-toolkit/docs/conventions.md`](https://github.com/giantswarm/mcp-toolkit/blob/main/docs/conventions.md) paginated tool result contract.

**Behavioural change clients see:** every list tool now returns JSON of the shape

```json
{ "items": [...], "nextCursor": "..." }
```

instead of human-formatted text. `nextCursor` is omitted (or empty) when no more pages.

## Why JSON instead of the previous text format

The text format `Found N clusters:\n\n[FormatClusterInfo(c1)]\n---\n\n...` was pre-toolkit code that never thought about the structured-vs-text question. JSON is the right shape for MCP tool results because:

- **Pagination** is meaningful in JSON, near-impossible in prose.
- **The response-cap middleware** behaves correctly: an oversize JSON response gets a clean typed `response_too_large` error the LLM can react to (paginate, filter); a truncated `Found 1000 clusters:\n\n[half-formatted]` is the worst LLM failure mode — a syntactically-valid lie.
- **Composability**: chaining `list_clusters` → `get_cluster(name)` requires extracting names. `items[].name` is unambiguous; parsing `---`-separated prose blocks is brittle.
- **MCP convention**: `tools/list`, `resources/list`, etc. at the protocol layer are JSON-paginated. Tool results that return paginated lists should follow the same shape.

## What changed

| Tool | Pagination | Notes |
|---|---|---|
| `capi_list_clusters` | ✅ K8s continue token via `cursor`+`limit` args (default 50, max 200) | `search` arg preserved; search-mode loads all matches in one page since K8s can't express substring-match server-side |
| `capi_list_machines` | ✅ | |
| `capi_list_machinedeployments` | ✅ | |
| `capi_list_machinesets` | ✅ | |
| `capi_aws_list_clusters`, `capi_azure_list_clusters`, `capi_gcp_list_clusters`, `capi_vsphere_list_clusters` | ❌ JSON-shape only | These fetch the full namespace then filter by `InfrastructureRef.Kind` client-side — real pagination would need an accumulating server-side loop. Follow-up. |
| `capi_list_infrastructure_providers` | ❌ | Bounded enum (4 entries); single-page JSON. |

## New files

- **`pkg/capi/list.go`** — per-resource digest types (`ClusterListItem`, `MachineListItem`, `MachineDeploymentListItem`, `MachineSetListItem`) plus `ListXxxPage` methods that thread `client.Limit` + `client.Continue` through controller-runtime's client. Digests are small (name, namespace, status fields, key labels) so a 50-item page fits comfortably under the toolkit's 128 KiB response cap. The full Kubernetes object is still available via the corresponding `capi_get_*` tool.
- **`pkg/mcp/handlers/jsonresult.go`** — `paginatedResult(items, cursor)` and `pageLimit(raw, default, max)` helpers. Cursor type is `mcp.Cursor` per the conventions doc.
- **`pkg/mcp/handlers/jsonresult_test.go`** — locks in: empty cursor is omitted; non-empty cursor is included; `pageLimit` clamps and defaults.

## Out of scope (separate follow-ups)

- GET tools (`capi_get_cluster`, `capi_get_machine`, etc.) still return text. They should be JSON too for the same composability reasons, but single-resource gets don't paginate so they're a separate cleanup.
- Provider-specific list tools' real pagination (server-side loop accumulating filtered items until limit-worth match).

## Verification

- `go build ./...`, `go vet ./...` clean.
- `go test ./...` passes (new unit tests for `paginatedResult` shape contract + `pageLimit` boundaries).
- Smoke test of the toolkit adoption (PR #113) already proved /healthz/readyz behaviour; this PR is purely tool-shape.

## Depends on

#113 — branched off `adopt-mcp-toolkit` so it benefits from the toolkit's `responsecap` middleware. Merge in order.