### PR TITLE
ci: enable split-china-push for the Aliyun mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,13 +26,14 @@ workflows:
             ignore:
             - main
 
-    # Tag builds: push multi-arch image to gsoci (primary registry).
-    # Chart push depends on this completing successfully.
+    # Tag builds: push multi-arch image to gsoci + gsociprivate. Aliyun is
+    # handled by the sync-china-registry job below (orb's split-china-push
+    # mechanism), so the buildx push no longer crosses the Pacific.
     - architect/push-to-registries:
         context: architect
         multiarch: true
-        name: push-to-gsoci-release
-        registries-data: "public gsoci.azurecr.io ACR_GSOCI_USERNAME ACR_GSOCI_PASSWORD true"
+        name: push-to-registries-release
+        split-china-push: true
         requires:
         - go-build-mcp-capi
         filters:
@@ -41,13 +42,14 @@ workflows:
           branches:
             ignore: /.*/
 
-    # Tag builds: push multi-arch image to all registries (including China mirrors).
-    - architect/push-to-registries:
+    # Mirror gsoci -> Aliyun via the in-China giantswarm/galaxy-runner. Runs
+    # in parallel with the chart catalog push; an Aliyun mirror failure does
+    # NOT block the chart publish.
+    - architect/sync-china-registry:
         context: architect
-        multiarch: true
-        name: push-to-all-registries-release
+        name: sync-china-registry
         requires:
-        - go-build-mcp-capi
+        - push-to-registries-release
         filters:
           tags:
             only: /^v.*/
@@ -100,7 +102,9 @@ workflows:
             ignore:
             - main
 
-    # Tag: push chart after tests + gsoci image
+    # Tag: push chart after tests + the gsoci image. Intentionally does NOT
+    # depend on sync-china-registry so the chart catalog can publish even if
+    # the in-China Aliyun mirror is slow or fails.
     - architect/push-to-app-catalog:
         executor: app-build-suite
         context: architect
@@ -110,7 +114,7 @@ workflows:
         chart: mcp-capi
         requires:
         - execute chart tests
-        - push-to-gsoci-release
+        - push-to-registries-release
         filters:
           tags:
             only: /^v.*/


### PR DESCRIPTION
## Summary

- Drop the `push-to-gsoci-release` + `push-to-all-registries-release` workaround pair.
- Replace with a single `push-to-registries-release` job using `split-china-push: true`.
- Add a companion `architect/sync-china-registry` job that mirrors gsoci -> Aliyun on the in-China `giantswarm/galaxy-runner`.
- Rewire `push-mcp-capi-to-giantswarm-app-catalog-release` to depend on `push-to-registries-release` instead of the dropped `push-to-gsoci-release`.

## Why

`split-china-push` (orb v7.1.0+) is the upstream fix for the Aliyun cross-Pacific timeout. The buildx push goes to gsoci/gsociprivate only (no Aliyun), and a separate `sync-china-registry` job running on the China-resident `giantswarm/galaxy-runner` uses `regctl image copy` (via the Singapore geo-replica + 10x retries) to mirror gsoci -> Aliyun. Chart catalog publishes are not blocked by Aliyun.

## Test plan

- [x] Branch CI exercises the unchanged amd64 `push-to-registries` job on this PR.
- [ ] Next `v*` tag exercises the new `split-china-push` + `sync-china-registry` flow end-to-end.


Made with [Cursor](https://cursor.com)