### PR TITLE
ci: bump giantswarm/architect orb to 8.2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@8.1.0
+  architect: giantswarm/architect@8.2.1
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,7 @@ workflows:
 
     - architect/push-to-app-catalog:
         executor: app-build-suite
+        sign: false
         context: architect
         name: build-mcp-capi-chart
         app_catalog: giantswarm-catalog
@@ -89,6 +90,7 @@ workflows:
     # Branch: push chart after tests + amd64 image
     - architect/push-to-app-catalog:
         executor: app-build-suite
+        sign: false
         context: architect
         name: push-mcp-capi-to-giantswarm-app-catalog
         app_catalog: giantswarm-catalog
@@ -107,6 +109,7 @@ workflows:
     # the in-China Aliyun mirror is slow or fails.
     - architect/push-to-app-catalog:
         executor: app-build-suite
+        sign: false
         context: architect
         name: push-mcp-capi-to-giantswarm-app-catalog-release
         app_catalog: giantswarm-catalog


### PR DESCRIPTION
## Summary

Bump `giantswarm/architect` orb `8.1.0` -> `8.2.1`.

## Why

v8.2.1 ships [architect-orb#767](https://github.com/giantswarm/architect-orb/pull/767), which makes the shared `image-login-to-registries` command POSIX-portable. The v8.1.0 refactor (#736) had accidentally introduced bash-only `${!var}` indirect expansion and `[[ ... ]]` test brackets, which BusyBox `/bin/sh` (used by the `regctl` executor under `architect/sync-china-registry`) rejects with `/bin/sh: syntax error: bad substitution`.

Since this repo migrated to `split-china-push: true` + `sync-china-registry`, every tag pipeline's mirror step has been failing before any login was attempted -- so no image has actually been mirrored gsoci -> Aliyun since 2026-05-18. This bump unblocks the next tag pipeline's mirror step.

v8.2.x also enables, by default, cosign keyless signing, SLSA provenance, and SBOM attestations for public images and Helm charts (closes the supply-chain loop for public artifacts in this repo).

## Test plan

- [x] Branch CI exercises the bumped orb on this PR.
- [ ] Next `v*` tag exercises `sync-china-registry` end-to-end (the gsoci side already works under 8.1.0; the Aliyun mirror is the new behaviour being validated).