### PR TITLE
ci: bump giantswarm/architect orb to 8.2.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@8.2.1
+  architect: giantswarm/architect@8.2.2
 
 workflows:
   build:
@@ -58,7 +58,6 @@ workflows:
 
     - architect/push-to-app-catalog:
         executor: app-build-suite
-        sign: false
         context: architect
         name: build-mcp-capi-chart
         app_catalog: giantswarm-catalog
@@ -90,7 +89,6 @@ workflows:
     # Branch: push chart after tests + amd64 image
     - architect/push-to-app-catalog:
         executor: app-build-suite
-        sign: false
         context: architect
         name: push-mcp-capi-to-giantswarm-app-catalog
         app_catalog: giantswarm-catalog
@@ -109,7 +107,6 @@ workflows:
     # the in-China Aliyun mirror is slow or fails.
     - architect/push-to-app-catalog:
         executor: app-build-suite
-        sign: false
         context: architect
         name: push-mcp-capi-to-giantswarm-app-catalog-release
         app_catalog: giantswarm-catalog


### PR DESCRIPTION
## Summary

Bump `giantswarm/architect` orb `8.2.1` -> `8.2.2` and re-enable cosign chart signing.

## Why

v8.2.2 ships [architect-orb#772](https://github.com/giantswarm/architect-orb/pull/772), which bumps the `app-build-suite` executor image from `1.8.0-circleci` to `1.8.1-circleci`. The new image includes the `cosign` binary, closing [architect-orb#769](https://github.com/giantswarm/architect-orb/issues/769).

This PR also removes the `sign: false` opt-out lines this repo added on 2026-05-19 as a workaround. Chart catalog publishes will now be cosign-signed end-to-end like the image publishes already are (the `push-to-registries` cosign path has been working since 8.2.0).

## Test plan

- [x] Branch CI exercises the bumped orb on this PR.
- [ ] Next `v*` tag exercises `push-to-app-catalog-release` with cosign keyless signing end-to-end.