### PR TITLE
fix(ci): install integration test binaries in CircleCI and relax yamllint line length

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ workflows:
         context: architect
         name: go-build-mcp-capi
         binary: mcp-capi
+        pre_test_target: install-test-binaries
         filters:
           tags:
             only: /^v.*/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,16 +36,8 @@ jobs:
           go install
           github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
 
-      - name: Install kine
-        run: go install github.com/k3s-io/kine@v0.14.12
-
-      - name: Install kube-apiserver
-        run: |
-          APISERVER_URL="https://dl.k8s.io/v1.35.2"
-          APISERVER_URL+="/bin/linux/amd64/kube-apiserver"
-          curl -fsSL "${APISERVER_URL}" \
-            -o "$(go env GOPATH)/bin/kube-apiserver"
-          chmod +x "$(go env GOPATH)/bin/kube-apiserver"
+      - name: Install kine and kube-apiserver
+        run: make install-test-binaries
 
       - name: Run yamllint
         run: >-

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,8 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 120
+  comments:
+    min-spaces-from-content: 1

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -3,6 +3,7 @@ KUBE_APISERVER_VERSION := v1.35.2
 
 .PHONY: install-test-binaries
 install-test-binaries: ## Install kine and kube-apiserver needed by integration tests (Linux amd64).
+	mkdir -p "$(shell go env GOPATH)/bin"
 	curl -fsSL "https://github.com/k3s-io/kine/releases/download/$(KINE_VERSION)/kine-amd64" \
 		-o "$(shell go env GOPATH)/bin/kine"
 	chmod +x "$(shell go env GOPATH)/bin/kine"

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -1,0 +1,11 @@
+KINE_VERSION := v0.14.12
+KUBE_APISERVER_VERSION := v1.35.2
+
+.PHONY: install-test-binaries
+install-test-binaries: ## Install kine and kube-apiserver needed by integration tests (Linux amd64).
+	curl -fsSL "https://github.com/k3s-io/kine/releases/download/$(KINE_VERSION)/kine-amd64" \
+		-o "$(shell go env GOPATH)/bin/kine"
+	chmod +x "$(shell go env GOPATH)/bin/kine"
+	curl -fsSL "https://dl.k8s.io/$(KUBE_APISERVER_VERSION)/bin/linux/amd64/kube-apiserver" \
+		-o "$(shell go env GOPATH)/bin/kube-apiserver"
+	chmod +x "$(shell go env GOPATH)/bin/kube-apiserver"


### PR DESCRIPTION
## What this PR does

Fixes the two pre-existing CI failures on `main` that currently block all PRs (including #134):

### 1. CircleCI `go-build-mcp-capi`: missing `kine` / `kube-apiserver`

The architect orb's `go-build` job runs `go test ./...`, and `test/integration` needs `kine` and `kube-apiserver` binaries (via [k8senv](https://github.com/giantswarm/k8senv)). GitHub Actions installed them, CircleCI never did.

- New `Makefile.custom.mk` with an `install-test-binaries` target that downloads both binaries into `$(go env GOPATH)/bin`
- Wired into the orb job via `pre_test_target: install-test-binaries`
- GitHub Actions `ci.yaml` reuses the same target, so versions (kine v0.14.12, kube-apiserver v1.35.2) are pinned in one place
- kine is downloaded as the prebuilt static release binary instead of `go install`: its SQLite driver is cgo-only ([`//go:build cgo`](https://github.com/k3s-io/kine/blob/v0.14.12/pkg/drivers/sqlite/sqlite.go)) and the architect image has no C compiler, so a `go install` there would silently produce a kine without SQLite support

### 2. GitHub Actions yamllint: line-length errors

Renovate's SHA-pinned `uses:` lines (`uses: owner/action@<sha> # vX.Y.Z`) exceed yamllint's default 80-char limit; `main` has been red since #127/#130 merged. Added a `.yamllint` config raising `line-length` to 120 and allowing single-space comments, matching what Renovate generates.

## Verification

- `yamllint .github/workflows/auto-release.yaml .github/workflows/ci.yaml .goreleaser.yaml` passes locally
- Download URLs verified (HTTP 200); kine release binary confirmed statically linked (runs on the Alpine-based architect image)
- Both CI systems run on this PR itself

Once merged, #134 (architect orb v9) should go green after a rebase.