### PR TITLE
test: skip integration tests when kine/kube-apiserver are unavailable

### DIFF
--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/giantswarm/mcp-capi/test/harness"
@@ -16,6 +17,16 @@ const testNamespace = "test-clusters"
 const kubeconfigSecretKey = "value"
 
 func TestMain(m *testing.M) {
+	// The harness needs kine and kube-apiserver (installed via
+	// `make install-test-binaries`). Plain `go test ./...` runs without them
+	// (e.g. the generated CircleCI go-build job), so skip instead of failing;
+	// the Lint and Test workflow installs the binaries and keeps full coverage.
+	for _, bin := range []string{"kine", "kube-apiserver"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			fmt.Fprintf(os.Stderr, "skipping integration tests: %s not found in PATH (run `make install-test-binaries`)\n", bin)
+			os.Exit(0)
+		}
+	}
 	if err := harness.InitManager(); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to initialize test harness: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
## Problem

The generated CircleCI `go-build` job runs plain `go test ./...` without the `pre_test_target: install-test-binaries` hook the previous hand-written config had. The integration suite then hard-fails because `kine` and `kube-apiserver` are not in PATH:

```
failed to initialize test harness: ... kine binary not found: exec: "kine": executable file not found in $PATH
```

## Solution

Skip the integration package gracefully when the test binaries are missing. The Lint and Test workflow (`ci.yaml`) installs them via `make install-test-binaries`, so full integration coverage is retained there.

Made with [Cursor](https://cursor.com)